### PR TITLE
Lazy instance can be referred as the name of the class

### DIFF
--- a/spec/PHPSpec2/Matcher/TrueMatcher.php
+++ b/spec/PHPSpec2/Matcher/TrueMatcher.php
@@ -25,7 +25,7 @@ class TrueMatcher implements Specification
 
     function does_not_complains_when_matching_true()
     {
-        $this->object->should_not_throw('PHPSpec2\Exception\Example\BooleanNotEqualException')
+        $this->trueMatcher->should_not_throw('PHPSpec2\Exception\Example\BooleanNotEqualException')
              ->during('positiveMatch', array('be_true', true, array()));
         
     }

--- a/src/PHPSpec2/Tester.php
+++ b/src/PHPSpec2/Tester.php
@@ -84,7 +84,12 @@ class Tester
         }
 
         $instance = $spec->newInstance();
-        $instance->object = new ObjectStub($subject, $this->matchers);
+
+        $className = substr($spec->getName(), (int)strrpos($spec->getName(), '\\') + 1);
+        $className = strtolower($className[0]) . substr($className, 1);
+        $instance->$className = new ObjectStub($subject, $this->matchers);
+        $instance->object = $instance->$className;
+
         $stubs = $this->getStubsForExample($instance, $example);
 
         if (defined('PHPSPEC_ERROR_REPORTING')) {


### PR DESCRIPTION
So basically, instead of using $this->object I can use a more explicit name based on the last segment of a fully qualified class name.

describing MyVendor\SomeBundle\Whatever\ParkingLotCalculator

I can use:

$this->parkingLotCalculator->should...

instead of only (the maybe too vague)

$this->object
