### PR TITLE
Refactored expectations and matchers to be camelcased

### DIFF
--- a/spec/PHPSpec2/Matcher/ComparisonMatcher.php
+++ b/spec/PHPSpec2/Matcher/ComparisonMatcher.php
@@ -23,7 +23,7 @@ class ComparisonMatcher implements Specification
     {
         foreach ($this->allComparisonMatcherAliases() as $alias) {
             $this->object->shouldNotThrow('PHPSpec2\Exception\Example\FailureException')
-                    ->during('positiveMatch', array($alias, '', array('')));
+                ->during('positiveMatch', array($alias, '', array('')));
         }
     }
 
@@ -34,7 +34,7 @@ class ComparisonMatcher implements Specification
     {
         foreach ($this->allComparisonMatcherAliases() as $alias) {
             $this->object->shouldNotThrow('PHPSpec2\Exception\Example\FailureException')
-                    ->during('positiveMatch', array($alias, 'chuck', array('chuck')));
+                ->during('positiveMatch', array($alias, 'chuck', array('chuck')));
         }
     }
 
@@ -46,7 +46,7 @@ class ComparisonMatcher implements Specification
         foreach ($this->allComparisonMatcherAliases() as $alias) {
             foreach ($this->phpEmptishValues() as $empty) {
                 $this->object->shouldNotThrow('PHPSpec2\Exception\Example\FailureException')
-                        ->during('positiveMatch', array($alias, '', array($empty)));
+                    ->during('positiveMatch', array($alias, '', array($empty)));
             }
         }
     }
@@ -59,7 +59,7 @@ class ComparisonMatcher implements Specification
         foreach ($this->allComparisonMatcherAliases() as $alias) {
             foreach ($this->phpEmptishValues() as $empty) {
                 $this->object->shouldNotThrow('PHPSpec2\Exception\Example\FailureException')
-                        ->during('positiveMatch', array($alias, 0, array($empty)));
+                    ->during('positiveMatch', array($alias, 0, array($empty)));
             }
         }
     }
@@ -72,7 +72,7 @@ class ComparisonMatcher implements Specification
         foreach ($this->allComparisonMatcherAliases() as $alias) {
             foreach ($this->phpEmptishValues() as $empty) {
                 $this->object->shouldNotThrow('PHPSpec2\Exception\Example\FailureException')
-                        ->during('positiveMatch', array($alias, null, array($empty)));
+                    ->during('positiveMatch', array($alias, null, array($empty)));
             }
         }
     }
@@ -206,9 +206,8 @@ class ComparisonMatcher implements Specification
                 // we need a booleans not equal exception
                 if ($value === true) $value = false;
 
-                $this->object->shouldThrow(
-                    $this->failureExceptionFor($type)
-                )->during('positiveMatch', array($alias, $value, array('different_value')));
+                $this->object->shouldThrow($this->failureExceptionFor($type))
+                    ->during('positiveMatch', array($alias, $value, array('different_value')));
             }
         }
     }
@@ -220,7 +219,8 @@ class ComparisonMatcher implements Specification
                 $this->object->shouldThrow(
                     'PHPSpec2\Exception\Example\FailureException',
                     $this->mismatchMessageFor($type)
-                )->during('negativeMatch', array($alias, $value, array($value)));
+                )
+                ->during('negativeMatch', array($alias, $value, array($value)));
             }
         }
     }

--- a/spec/PHPSpec2/Matcher/ComparisonMatcher.php
+++ b/spec/PHPSpec2/Matcher/ComparisonMatcher.php
@@ -9,20 +9,20 @@ class ComparisonMatcher implements Specification
 {
     private static $NO_ARGUMENTS = array();
 
-    function should_support_all_aliases_for_all_kinds_of_subjects()
+    function it_should_support_all_aliases_for_allKindsOfSubjects()
     {
-        foreach ($this->all_comparison_matcher_aliases() as $alias) {
-            $this->supports_alias_for_all_kinds($alias, $this->object);
+        foreach ($this->allComparisonMatcherAliases() as $alias) {
+            $this->supportsAliasForAllKinds($alias, $this->object);
         }
     }
 
     /**
      * @Context "Positive Matching"
      */
-    function matches_empty_string_using_comparison_operator()
+    function it_matches_empty_string_using_comparison_operator()
     {
-        foreach ($this->all_comparison_matcher_aliases() as $alias) {
-            $this->object->should_not_throw('PHPSpec2\Exception\Example\FailureException')
+        foreach ($this->allComparisonMatcherAliases() as $alias) {
+            $this->object->shouldNotThrow('PHPSpec2\Exception\Example\FailureException')
                     ->during('positiveMatch', array($alias, '', array('')));
         }
     }
@@ -30,10 +30,10 @@ class ComparisonMatcher implements Specification
     /**
      * @Context "Positive Matching"
      */
-    function matches_not_empty_string_using_comparison_operator()
+    function it_matches_not_empty_string_using_comparison_operator()
     {
-        foreach ($this->all_comparison_matcher_aliases() as $alias) {
-            $this->object->should_not_throw('PHPSpec2\Exception\Example\FailureException')
+        foreach ($this->allComparisonMatcherAliases() as $alias) {
+            $this->object->shouldNotThrow('PHPSpec2\Exception\Example\FailureException')
                     ->during('positiveMatch', array($alias, 'chuck', array('chuck')));
         }
     }
@@ -41,11 +41,11 @@ class ComparisonMatcher implements Specification
     /**
      * @Context "Positive Matching"
      */
-    function matches_empty_string_with_emptish_values_using_comparison_operator()
+    function it_matches_empty_string_with_emptish_values_using_comparison_operator()
     {
-        foreach ($this->all_comparison_matcher_aliases() as $alias) {
-            foreach ($this->php_emptish_values() as $empty) {
-                $this->object->should_not_throw('PHPSpec2\Exception\Example\FailureException')
+        foreach ($this->allComparisonMatcherAliases() as $alias) {
+            foreach ($this->phpEmptishValues() as $empty) {
+                $this->object->shouldNotThrow('PHPSpec2\Exception\Example\FailureException')
                         ->during('positiveMatch', array($alias, '', array($empty)));
             }
         }
@@ -54,11 +54,11 @@ class ComparisonMatcher implements Specification
     /**
      * @Context "Positive Matching"
      */
-    function matches_zero_with_emptish_values_using_comparison_operator()
+    function it_matches_zero_with_emptish_values_using_comparison_operator()
     {
-        foreach ($this->all_comparison_matcher_aliases() as $alias) {
-            foreach ($this->php_emptish_values() as $empty) {
-                $this->object->should_not_throw('PHPSpec2\Exception\Example\FailureException')
+        foreach ($this->allComparisonMatcherAliases() as $alias) {
+            foreach ($this->phpEmptishValues() as $empty) {
+                $this->object->shouldNotThrow('PHPSpec2\Exception\Example\FailureException')
                         ->during('positiveMatch', array($alias, 0, array($empty)));
             }
         }
@@ -67,11 +67,11 @@ class ComparisonMatcher implements Specification
     /**
      * @Context "Positive Matching"
      */
-    function matches_null_with_emptish_values_using_comparison_operator()
+    function it_matches_null_with_emptish_values_using_comparison_operator()
     {
-        foreach ($this->all_comparison_matcher_aliases() as $alias) {
-            foreach ($this->php_emptish_values() as $empty) {
-                $this->object->should_not_throw('PHPSpec2\Exception\Example\FailureException')
+        foreach ($this->allComparisonMatcherAliases() as $alias) {
+            foreach ($this->phpEmptishValues() as $empty) {
+                $this->object->shouldNotThrow('PHPSpec2\Exception\Example\FailureException')
                         ->during('positiveMatch', array($alias, null, array($empty)));
             }
         }
@@ -80,11 +80,11 @@ class ComparisonMatcher implements Specification
     /**
      * @Context "Positive Matching"
      */
-    function matches_false_with_emptish_values_using_comparison_operator()
+    function it_matches_false_with_emptish_values_using_comparison_operator()
     {
-        foreach ($this->all_comparison_matcher_aliases() as $alias) {
-            foreach ($this->php_emptish_values() as $empty) {
-                $this->object->should_not_throw('PHPSpec2\Exception\Example\FailureException')
+        foreach ($this->allComparisonMatcherAliases() as $alias) {
+            foreach ($this->phpEmptishValues() as $empty) {
+                $this->object->shouldNotThrow('PHPSpec2\Exception\Example\FailureException')
                         ->during('positiveMatch', array($alias, false, array($empty)));
             }
         }
@@ -93,15 +93,15 @@ class ComparisonMatcher implements Specification
     /**
      * @Context "Positive Matching"
      */
-    function does_not_match_non_empty_different_value()
+    function it_does_not_match_non_empty_different_value()
     {
-        foreach ($this->all_comparison_matcher_aliases() as $alias) {
-            foreach ($this->all_kinds_of_subjects() as $value) {
+        foreach ($this->allComparisonMatcherAliases() as $alias) {
+            foreach ($this->allKindsOfSubjects() as $value) {
 
                 // skip true
                 if ($value === true) continue;
 
-                $this->object->should_throw('PHPSpec2\Exception\Example\FailureException')
+                $this->object->shouldThrow('PHPSpec2\Exception\Example\FailureException')
                         ->during('positiveMatch', array($alias, 'different_value',array($value)));
             }
         }
@@ -110,10 +110,10 @@ class ComparisonMatcher implements Specification
     /**
      * @Context "Negative Matching"
      */
-    function mismatches_empty_string_using_comparison_operator()
+    function it_mismatches_empty_string_using_comparison_operator()
     {
-        foreach ($this->all_comparison_matcher_aliases() as $alias) {
-            $this->object->should_throw('PHPSpec2\Exception\Example\FailureException')
+        foreach ($this->allComparisonMatcherAliases() as $alias) {
+            $this->object->shouldThrow('PHPSpec2\Exception\Example\FailureException')
                     ->during('negativeMatch', array($alias, '', array('')));
         }
     }
@@ -121,10 +121,10 @@ class ComparisonMatcher implements Specification
     /**
      * @Context "Negative Matching"
      */
-    function mismatches_not_empty_string_using_comparison_operator($matcher)
+    function it_mismatches_not_empty_string_using_comparison_operator($matcher)
     {
-        foreach ($this->all_comparison_matcher_aliases() as $alias) {
-            $this->object->should_throw('PHPSpec2\Exception\Example\FailureException')
+        foreach ($this->allComparisonMatcherAliases() as $alias) {
+            $this->object->shouldThrow('PHPSpec2\Exception\Example\FailureException')
                     ->during('negativeMatch', array($alias, 'chuck', array('chuck')));
         }
     }
@@ -132,11 +132,11 @@ class ComparisonMatcher implements Specification
     /**
      * @Context "Negative Matching"
      */
-    function mismatches_empty_string_with_emptish_values_using_comparison_operator()
+    function it_mismatches_empty_string_with_emptish_values_using_comparison_operator()
     {
-        foreach ($this->all_comparison_matcher_aliases() as $alias) {
-            foreach ($this->php_emptish_values() as $empty) {
-                $this->object->should_throw('PHPSpec2\Exception\Example\FailureException')
+        foreach ($this->allComparisonMatcherAliases() as $alias) {
+            foreach ($this->phpEmptishValues() as $empty) {
+                $this->object->shouldThrow('PHPSpec2\Exception\Example\FailureException')
                         ->during('negativeMatch', array($alias, '', array($empty)));
             }
         }
@@ -145,11 +145,11 @@ class ComparisonMatcher implements Specification
     /**
      * @Context "Negative Matching"
      */
-    function mismatches_zero_with_emptish_values_using_comparison_operator()
+    function it_mismatches_zero_with_emptish_values_using_comparison_operator()
     {
-        foreach ($this->all_comparison_matcher_aliases() as $alias) {
-            foreach ($this->php_emptish_values() as $empty) {
-                $this->object->should_throw('PHPSpec2\Exception\Example\FailureException')
+        foreach ($this->allComparisonMatcherAliases() as $alias) {
+            foreach ($this->phpEmptishValues() as $empty) {
+                $this->object->shouldThrow('PHPSpec2\Exception\Example\FailureException')
                         ->during('negativeMatch', array($alias, 0, array($empty)));
             }
         }
@@ -158,11 +158,11 @@ class ComparisonMatcher implements Specification
     /**
      * @Context "Negative Matching"
      */
-    function mismatches_null_with_emptish_values_using_comparison_operator()
+    function it_mismatches_null_with_emptish_values_using_comparison_operator()
     {
-        foreach ($this->all_comparison_matcher_aliases() as $alias) {
-            foreach ($this->php_emptish_values() as $empty) {
-                $this->object->should_throw('PHPSpec2\Exception\Example\FailureException')
+        foreach ($this->allComparisonMatcherAliases() as $alias) {
+            foreach ($this->phpEmptishValues() as $empty) {
+                $this->object->shouldThrow('PHPSpec2\Exception\Example\FailureException')
                         ->during('negativeMatch', array($alias, null, array($empty)));
             }
         }
@@ -171,11 +171,11 @@ class ComparisonMatcher implements Specification
     /**
      * @Context "Negative Matching"
      */
-    function mismatches_false_with_emptish_values_using_comparison_operator()
+    function it_mismatches_false_with_emptish_values_using_comparison_operator()
     {
-        foreach ($this->all_comparison_matcher_aliases() as $alias) {
-            foreach ($this->php_emptish_values() as $empty) {
-                $this->object->should_throw('PHPSpec2\Exception\Example\FailureException')
+        foreach ($this->allComparisonMatcherAliases() as $alias) {
+            foreach ($this->phpEmptishValues() as $empty) {
+                $this->object->shouldThrow('PHPSpec2\Exception\Example\FailureException')
                         ->during('negativeMatch', array($alias, false, array($empty)));
             }
         }
@@ -184,55 +184,55 @@ class ComparisonMatcher implements Specification
     /**
      * @Context "Negative Matching"
      */
-    function mismatches_on_non_empty_different_value()
+    function it_mismatches_on_non_empty_different_value()
     {
-        foreach ($this->all_comparison_matcher_aliases() as $alias) {
-            foreach ($this->all_kinds_of_subjects() as $value) {
+        foreach ($this->allComparisonMatcherAliases() as $alias) {
+            foreach ($this->allKindsOfSubjects() as $value) {
 
                 // skip true
                 if ($value === true) continue;
 
-                $this->object->should_not_throw('PHPSpec2\Exception\Example\FailureException')
+                $this->object->shouldNotThrow('PHPSpec2\Exception\Example\FailureException')
                         ->during('negativeMatch', array($alias, 'different_value',array($value)));
             }
         }
     }
-    
+
     function match_throws_type_specific_failure_exception()
     {
-        foreach ($this->all_comparison_matcher_aliases() as $alias) {
-            foreach ($this->all_kinds_of_subjects() as $type => $value) {
-                
+        foreach ($this->allComparisonMatcherAliases() as $alias) {
+            foreach ($this->allKindsOfSubjects() as $type => $value) {
+
                 // we need a booleans not equal exception
                 if ($value === true) $value = false;
-                
-                $this->object->should_throw(
-                    $this->failure_exception_for($type)
+
+                $this->object->shouldThrow(
+                    $this->failureExceptionFor($type)
                 )->during('positiveMatch', array($alias, $value, array('different_value')));
             }
         }
     }
-    
-    function mismatch_throws_with_type_specific_message()
+
+    function it_mismatch_throws_with_type_specific_message()
     {
-        foreach ($this->all_comparison_matcher_aliases() as $alias) {
-            foreach ($this->all_kinds_of_subjects() as $type => $value) {                
-                $this->object->should_throw(
+        foreach ($this->allComparisonMatcherAliases() as $alias) {
+            foreach ($this->allKindsOfSubjects() as $type => $value) {
+                $this->object->shouldThrow(
                     'PHPSpec2\Exception\Example\FailureException',
-                    $this->mismatch_message_for($type)
+                    $this->mismatchMessageFor($type)
                 )->during('negativeMatch', array($alias, $value, array($value)));
             }
         }
     }
 
-    private function supports_alias_for_all_kinds($alias, $matcher)
+    private function supportsAliasForAllKinds($alias, $matcher)
     {
-        foreach ($this->all_kinds_of_subjects() as $kind => $subject) {
-            $matcher->supports($alias, $subject, self::$NO_ARGUMENTS)->should_be_true();
+        foreach ($this->allKindsOfSubjects() as $kind => $subject) {
+            $matcher->supports($alias, $subject, self::$NO_ARGUMENTS)->shouldBeTrue();
         }
     }
 
-    private function all_kinds_of_subjects()
+    private function allKindsOfSubjects()
     {
         return array(
             'string' => 'some_string',
@@ -244,7 +244,7 @@ class ComparisonMatcher implements Specification
         );
     }
 
-    private function php_emptish_values()
+    private function phpEmptishValues()
     {
         return array(
             "",
@@ -254,14 +254,14 @@ class ComparisonMatcher implements Specification
         );
     }
 
-    private function all_comparison_matcher_aliases()
+    private function allComparisonMatcherAliases()
     {
         return array(
-            'be_like'
+            'beLike'
         );
     }
-    
-    private function failure_exception_for($type)
+
+    private function failureExceptionFor($type)
     {
         $namespace = "PHPSpec2\\Exception\\Example\\";
         $exceptions = array(
@@ -274,8 +274,8 @@ class ComparisonMatcher implements Specification
         );
         return $namespace . $exceptions[$type];
     }
-    
-    private function mismatch_message_for($type)
+
+    private function mismatchMessageFor($type)
     {
         $messages = array(
             'string' => 'Strings are equal, but they shouldn\'t be',

--- a/spec/PHPSpec2/Matcher/IdentityMatcher.php
+++ b/spec/PHPSpec2/Matcher/IdentityMatcher.php
@@ -9,7 +9,7 @@ class IdentityMatcher implements Specification
 {
     private static $NO_ARGUMENTS = array();
 
-    function should_support_all_aliases_for_allKindsOfSubjects()
+    function it_should_support_all_aliases_for_allKindsOfSubjects()
     {
         foreach ($this->allIdentityMatcherAliases() as $alias) {
             $this->supportsAliasForAllKinds($alias, $this->object);
@@ -19,7 +19,7 @@ class IdentityMatcher implements Specification
     /**
      * @Context "Positive Matching"
      */
-    function matches_empty_string_using_identity_operator()
+    function it_matches_empty_string_using_identity_operator()
     {
         foreach ($this->allIdentityMatcherAliases() as $alias) {
             $this->object->shouldNotThrow('PHPSpec2\Exception\Example\FailureException')
@@ -30,7 +30,7 @@ class IdentityMatcher implements Specification
     /**
      * @Context "Positive Matching"
      */
-    function matches_not_empty_string_using_identity_operator()
+    function it_matches_not_empty_string_using_identity_operator()
     {
         foreach ($this->allIdentityMatcherAliases() as $alias) {
             $this->object->shouldNotThrow('PHPSpec2\Exception\Example\FailureException')
@@ -41,7 +41,7 @@ class IdentityMatcher implements Specification
     /**
      * @Context "Positive Matching"
      */
-    function does_not_matches_empty_string_with_emptish_values_using_identity_operator()
+    function it_does_not_matches_empty_string_with_emptish_values_using_identity_operator()
     {
         foreach ($this->allIdentityMatcherAliases() as $alias) {
             foreach ($this->phpEmptishValues() as $empty) {
@@ -55,7 +55,7 @@ class IdentityMatcher implements Specification
     /**
      * @Context "Positive Matching"
      */
-    function does_not_matches_zero_with_emptish_values_using_identity_operator()
+    function it_does_not_matches_zero_with_emptish_values_using_identity_operator()
     {
         foreach ($this->allIdentityMatcherAliases() as $alias) {
             foreach ($this->phpEmptishValues() as $empty) {
@@ -69,7 +69,7 @@ class IdentityMatcher implements Specification
     /**
      * @Context "Positive Matching"
      */
-    function does_not_matches_null_with_emptish_values_using_identity_operator()
+    function it_does_not_matches_null_with_emptish_values_using_identity_operator()
     {
         foreach ($this->allIdentityMatcherAliases() as $alias) {
             foreach ($this->phpEmptishValues() as $empty) {
@@ -83,7 +83,7 @@ class IdentityMatcher implements Specification
     /**
      * @Context "Positive Matching"
      */
-    function does_matches_false_with_emptish_values_using_identity_operator()
+    function it_does_matches_false_with_emptish_values_using_identity_operator()
     {
         foreach ($this->allIdentityMatcherAliases() as $alias) {
             foreach ($this->phpEmptishValues() as $empty) {
@@ -97,7 +97,7 @@ class IdentityMatcher implements Specification
     /**
      * @Context "Positive Matching"
      */
-    function does_not_match_non_empty_different_value()
+    function it_does_not_match_non_empty_different_value()
     {
         foreach ($this->allIdentityMatcherAliases() as $alias) {
             foreach ($this->allKindsOfSubjects() as $value) {
@@ -114,7 +114,7 @@ class IdentityMatcher implements Specification
     /**
      * @Context "Negative Matching"
      */
-    function mismatches_empty_string_using_identity_operator()
+    function it_mismatches_empty_string_using_identity_operator()
     {
         foreach ($this->allIdentityMatcherAliases() as $alias) {
             $this->object->shouldThrow('PHPSpec2\Exception\Example\FailureException')
@@ -125,7 +125,7 @@ class IdentityMatcher implements Specification
     /**
      * @Context "Negative Matching"
      */
-    function mismatches_not_empty_string_using_identity_operator($matcher)
+    function it_mismatches_not_empty_string_using_identity_operator($matcher)
     {
         foreach ($this->allIdentityMatcherAliases() as $alias) {
             $this->object->shouldThrow('PHPSpec2\Exception\Example\FailureException')
@@ -136,7 +136,7 @@ class IdentityMatcher implements Specification
     /**
      * @Context "Negative Matching"
      */
-    function mismatches_empty_string_with_emptish_values_using_identity_operator()
+    function it_mismatches_empty_string_with_emptish_values_using_identity_operator()
     {
         foreach ($this->allIdentityMatcherAliases() as $alias) {
             foreach ($this->phpEmptishValues() as $empty) {
@@ -150,7 +150,7 @@ class IdentityMatcher implements Specification
     /**
      * @Context "Negative Matching"
      */
-    function mismatches_zero_with_emptish_values_using_identity_operator()
+    function it_mismatches_zero_with_emptish_values_using_identity_operator()
     {
         foreach ($this->allIdentityMatcherAliases() as $alias) {
             foreach ($this->phpEmptishValues() as $empty) {
@@ -164,7 +164,7 @@ class IdentityMatcher implements Specification
     /**
      * @Context "Negative Matching"
      */
-    function mismatches_null_with_emptish_values_using_identity_operator()
+    function it_mismatches_null_with_emptish_values_using_identity_operator()
     {
         foreach ($this->allIdentityMatcherAliases() as $alias) {
             foreach ($this->phpEmptishValues() as $empty) {
@@ -178,7 +178,7 @@ class IdentityMatcher implements Specification
     /**
      * @Context "Negative Matching"
      */
-    function mismatches_false_with_emptish_values_using_identity_operator()
+    function it_mismatches_false_with_emptish_values_using_identity_operator()
     {
         foreach ($this->allIdentityMatcherAliases() as $alias) {
             foreach ($this->phpEmptishValues() as $empty) {
@@ -192,7 +192,7 @@ class IdentityMatcher implements Specification
     /**
      * @Context "Negative Matching"
      */
-    function mismatches_on_non_empty_different_value()
+    function it_mismatches_on_non_empty_different_value()
     {
         foreach ($this->allIdentityMatcherAliases() as $alias) {
             foreach ($this->allKindsOfSubjects() as $value) {
@@ -206,7 +206,7 @@ class IdentityMatcher implements Specification
         }
     }
 
-    function match_throws_type_specific_failure_exception()
+    function its_match_throws_type_specific_failure_exception()
     {
         foreach ($this->allIdentityMatcherAliases() as $alias) {
             foreach ($this->allKindsOfSubjects() as $type => $value) {
@@ -221,7 +221,7 @@ class IdentityMatcher implements Specification
         }
     }
 
-    function mismatch_throws_with_type_specific_message()
+    function its_mismatch_throws_with_type_specific_message()
     {
         foreach ($this->allIdentityMatcherAliases() as $alias) {
             foreach ($this->allKindsOfSubjects() as $type => $value) {

--- a/spec/PHPSpec2/Matcher/IdentityMatcher.php
+++ b/spec/PHPSpec2/Matcher/IdentityMatcher.php
@@ -9,10 +9,10 @@ class IdentityMatcher implements Specification
 {
     private static $NO_ARGUMENTS = array();
 
-    function should_support_all_aliases_for_all_kinds_of_subjects()
+    function should_support_all_aliases_for_allKindsOfSubjects()
     {
-        foreach ($this->all_identity_matcher_aliases() as $alias) {
-            $this->supports_alias_for_all_kinds($alias, $this->object);
+        foreach ($this->allIdentityMatcherAliases() as $alias) {
+            $this->supportsAliasForAllKinds($alias, $this->object);
         }
     }
 
@@ -21,8 +21,8 @@ class IdentityMatcher implements Specification
      */
     function matches_empty_string_using_identity_operator()
     {
-        foreach ($this->all_identity_matcher_aliases() as $alias) {
-            $this->object->should_not_throw('PHPSpec2\Exception\Example\FailureException')
+        foreach ($this->allIdentityMatcherAliases() as $alias) {
+            $this->object->shouldNotThrow('PHPSpec2\Exception\Example\FailureException')
                     ->during('positiveMatch', array($alias, '', array('')));
         }
     }
@@ -32,8 +32,8 @@ class IdentityMatcher implements Specification
      */
     function matches_not_empty_string_using_identity_operator()
     {
-        foreach ($this->all_identity_matcher_aliases() as $alias) {
-            $this->object->should_not_throw('PHPSpec2\Exception\Example\FailureException')
+        foreach ($this->allIdentityMatcherAliases() as $alias) {
+            $this->object->shouldNotThrow('PHPSpec2\Exception\Example\FailureException')
                     ->during('positiveMatch', array($alias, 'chuck', array('chuck')));
         }
     }
@@ -43,10 +43,10 @@ class IdentityMatcher implements Specification
      */
     function does_not_matches_empty_string_with_emptish_values_using_identity_operator()
     {
-        foreach ($this->all_identity_matcher_aliases() as $alias) {
-            foreach ($this->php_emptish_values() as $empty) {
+        foreach ($this->allIdentityMatcherAliases() as $alias) {
+            foreach ($this->phpEmptishValues() as $empty) {
                 if ($empty === '') continue;
-                $this->object->should_throw('PHPSpec2\Exception\Example\FailureException')
+                $this->object->shouldThrow('PHPSpec2\Exception\Example\FailureException')
                         ->during('positiveMatch', array($alias, '', array($empty)));
             }
         }
@@ -57,10 +57,10 @@ class IdentityMatcher implements Specification
      */
     function does_not_matches_zero_with_emptish_values_using_identity_operator()
     {
-        foreach ($this->all_identity_matcher_aliases() as $alias) {
-            foreach ($this->php_emptish_values() as $empty) {
+        foreach ($this->allIdentityMatcherAliases() as $alias) {
+            foreach ($this->phpEmptishValues() as $empty) {
                 if ($empty === 0) continue;
-                $this->object->should_throw('PHPSpec2\Exception\Example\FailureException')
+                $this->object->shouldThrow('PHPSpec2\Exception\Example\FailureException')
                         ->during('positiveMatch', array($alias, 0, array($empty)));
             }
         }
@@ -71,10 +71,10 @@ class IdentityMatcher implements Specification
      */
     function does_not_matches_null_with_emptish_values_using_identity_operator()
     {
-        foreach ($this->all_identity_matcher_aliases() as $alias) {
-            foreach ($this->php_emptish_values() as $empty) {
+        foreach ($this->allIdentityMatcherAliases() as $alias) {
+            foreach ($this->phpEmptishValues() as $empty) {
                 if ($empty === null) continue;
-                $this->object->should_throw('PHPSpec2\Exception\Example\FailureException')
+                $this->object->shouldThrow('PHPSpec2\Exception\Example\FailureException')
                         ->during('positiveMatch', array($alias, null, array($empty)));
             }
         }
@@ -85,10 +85,10 @@ class IdentityMatcher implements Specification
      */
     function does_matches_false_with_emptish_values_using_identity_operator()
     {
-        foreach ($this->all_identity_matcher_aliases() as $alias) {
-            foreach ($this->php_emptish_values() as $empty) {
+        foreach ($this->allIdentityMatcherAliases() as $alias) {
+            foreach ($this->phpEmptishValues() as $empty) {
                 if ($empty === false) continue;
-                $this->object->should_throw('PHPSpec2\Exception\Example\FailureException')
+                $this->object->shouldThrow('PHPSpec2\Exception\Example\FailureException')
                         ->during('positiveMatch', array($alias, false, array($empty)));
             }
         }
@@ -99,13 +99,13 @@ class IdentityMatcher implements Specification
      */
     function does_not_match_non_empty_different_value()
     {
-        foreach ($this->all_identity_matcher_aliases() as $alias) {
-            foreach ($this->all_kinds_of_subjects() as $value) {
+        foreach ($this->allIdentityMatcherAliases() as $alias) {
+            foreach ($this->allKindsOfSubjects() as $value) {
 
                 // skip true
                 if ($value === true) continue;
 
-                $this->object->should_throw('PHPSpec2\Exception\Example\FailureException')
+                $this->object->shouldThrow('PHPSpec2\Exception\Example\FailureException')
                         ->during('positiveMatch', array($alias, 'different_value',array($value)));
             }
         }
@@ -116,8 +116,8 @@ class IdentityMatcher implements Specification
      */
     function mismatches_empty_string_using_identity_operator()
     {
-        foreach ($this->all_identity_matcher_aliases() as $alias) {
-            $this->object->should_throw('PHPSpec2\Exception\Example\FailureException')
+        foreach ($this->allIdentityMatcherAliases() as $alias) {
+            $this->object->shouldThrow('PHPSpec2\Exception\Example\FailureException')
                     ->during('negativeMatch', array($alias, '', array('')));
         }
     }
@@ -127,8 +127,8 @@ class IdentityMatcher implements Specification
      */
     function mismatches_not_empty_string_using_identity_operator($matcher)
     {
-        foreach ($this->all_identity_matcher_aliases() as $alias) {
-            $this->object->should_throw('PHPSpec2\Exception\Example\FailureException')
+        foreach ($this->allIdentityMatcherAliases() as $alias) {
+            $this->object->shouldThrow('PHPSpec2\Exception\Example\FailureException')
                     ->during('negativeMatch', array($alias, 'chuck', array('chuck')));
         }
     }
@@ -138,10 +138,10 @@ class IdentityMatcher implements Specification
      */
     function mismatches_empty_string_with_emptish_values_using_identity_operator()
     {
-        foreach ($this->all_identity_matcher_aliases() as $alias) {
-            foreach ($this->php_emptish_values() as $empty) {
+        foreach ($this->allIdentityMatcherAliases() as $alias) {
+            foreach ($this->phpEmptishValues() as $empty) {
                 if ($empty === '') continue;
-                $this->object->should_not_throw('PHPSpec2\Exception\Example\FailureException')
+                $this->object->shouldNotThrow('PHPSpec2\Exception\Example\FailureException')
                         ->during('negativeMatch', array($alias, '', array($empty)));
             }
         }
@@ -152,10 +152,10 @@ class IdentityMatcher implements Specification
      */
     function mismatches_zero_with_emptish_values_using_identity_operator()
     {
-        foreach ($this->all_identity_matcher_aliases() as $alias) {
-            foreach ($this->php_emptish_values() as $empty) {
+        foreach ($this->allIdentityMatcherAliases() as $alias) {
+            foreach ($this->phpEmptishValues() as $empty) {
                 if ($empty === 0) continue;
-                $this->object->should_not_throw('PHPSpec2\Exception\Example\FailureException')
+                $this->object->shouldNotThrow('PHPSpec2\Exception\Example\FailureException')
                         ->during('negativeMatch', array($alias, 0, array($empty)));
             }
         }
@@ -166,10 +166,10 @@ class IdentityMatcher implements Specification
      */
     function mismatches_null_with_emptish_values_using_identity_operator()
     {
-        foreach ($this->all_identity_matcher_aliases() as $alias) {
-            foreach ($this->php_emptish_values() as $empty) {
+        foreach ($this->allIdentityMatcherAliases() as $alias) {
+            foreach ($this->phpEmptishValues() as $empty) {
                 if ($empty === null) continue;
-                $this->object->should_not_throw('PHPSpec2\Exception\Example\FailureException')
+                $this->object->shouldNotThrow('PHPSpec2\Exception\Example\FailureException')
                         ->during('negativeMatch', array($alias, null, array($empty)));
             }
         }
@@ -180,10 +180,10 @@ class IdentityMatcher implements Specification
      */
     function mismatches_false_with_emptish_values_using_identity_operator()
     {
-        foreach ($this->all_identity_matcher_aliases() as $alias) {
-            foreach ($this->php_emptish_values() as $empty) {
+        foreach ($this->allIdentityMatcherAliases() as $alias) {
+            foreach ($this->phpEmptishValues() as $empty) {
                 if ($empty === false) continue;
-                $this->object->should_not_throw('PHPSpec2\Exception\Example\FailureException')
+                $this->object->shouldNotThrow('PHPSpec2\Exception\Example\FailureException')
                         ->during('negativeMatch', array($alias, false, array($empty)));
             }
         }
@@ -194,53 +194,53 @@ class IdentityMatcher implements Specification
      */
     function mismatches_on_non_empty_different_value()
     {
-        foreach ($this->all_identity_matcher_aliases() as $alias) {
-            foreach ($this->all_kinds_of_subjects() as $value) {
+        foreach ($this->allIdentityMatcherAliases() as $alias) {
+            foreach ($this->allKindsOfSubjects() as $value) {
 
                 // skip true
                 if ($value === true) continue;
 
-                $this->object->should_not_throw('PHPSpec2\Exception\Example\FailureException')
+                $this->object->shouldNotThrow('PHPSpec2\Exception\Example\FailureException')
                         ->during('negativeMatch', array($alias, 'different_value',array($value)));
             }
         }
     }
-    
+
     function match_throws_type_specific_failure_exception()
     {
-        foreach ($this->all_identity_matcher_aliases() as $alias) {
-            foreach ($this->all_kinds_of_subjects() as $type => $value) {
-                
+        foreach ($this->allIdentityMatcherAliases() as $alias) {
+            foreach ($this->allKindsOfSubjects() as $type => $value) {
+
                 // we need a booleans not equal exception
                 if ($value === true) $value = false;
-                
-                $this->object->should_throw(
-                    $this->failure_exception_for($type)
+
+                $this->object->shouldThrow(
+                    $this->failureExceptionFor($type)
                 )->during('positiveMatch', array($alias, $value, array('different_value')));
             }
         }
     }
-    
+
     function mismatch_throws_with_type_specific_message()
     {
-        foreach ($this->all_identity_matcher_aliases() as $alias) {
-            foreach ($this->all_kinds_of_subjects() as $type => $value) {                
-                $this->object->should_throw(
+        foreach ($this->allIdentityMatcherAliases() as $alias) {
+            foreach ($this->allKindsOfSubjects() as $type => $value) {
+                $this->object->shouldThrow(
                     'PHPSpec2\Exception\Example\FailureException',
-                    $this->mismatch_message_for($type)
+                    $this->missmatchMessageFor($type)
                 )->during('negativeMatch', array($alias, $value, array($value)));
             }
         }
     }
 
-    private function supports_alias_for_all_kinds($alias, $matcher)
+    private function supportsAliasForAllKinds($alias, $matcher)
     {
-        foreach ($this->all_kinds_of_subjects() as $kind => $subject) {
-            $matcher->supports($alias, $subject, self::$NO_ARGUMENTS)->should_be_true();
+        foreach ($this->allKindsOfSubjects() as $kind => $subject) {
+            $matcher->supports($alias, $subject, self::$NO_ARGUMENTS)->shouldBeTrue();
         }
     }
 
-    private function all_kinds_of_subjects()
+    private function allKindsOfSubjects()
     {
         return array(
             'string' => 'some_string',
@@ -252,7 +252,7 @@ class IdentityMatcher implements Specification
         );
     }
 
-    private function php_emptish_values()
+    private function phpEmptishValues()
     {
         return array(
             "",
@@ -262,14 +262,14 @@ class IdentityMatcher implements Specification
         );
     }
 
-    private function all_identity_matcher_aliases()
+    private function allIdentityMatcherAliases()
     {
         return array(
-            'equal', 'return', 'be_equal_to', 'be'
+            'equal', 'return', 'beEqualTo', 'be'
         );
     }
-    
-    private function failure_exception_for($type)
+
+    private function failureExceptionFor($type)
     {
         $namespace = "PHPSpec2\\Exception\\Example\\";
         $exceptions = array(
@@ -282,8 +282,8 @@ class IdentityMatcher implements Specification
         );
         return $namespace . $exceptions[$type];
     }
-    
-    private function mismatch_message_for($type)
+
+    private function missmatchMessageFor($type)
     {
         $messages = array(
             'string' => 'Strings are equal, but they shouldn\'t be',

--- a/spec/PHPSpec2/Matcher/MatchersCollection.php
+++ b/spec/PHPSpec2/Matcher/MatchersCollection.php
@@ -7,33 +7,30 @@ use PHPSpec2\Exception\Example\MatcherNotFoundException;
 
 class MatchersCollection implements Specification
 {
-
-    function will_complain_if_no_matchers_registered()
+    function it_will_complain_if_no_matchers_registered()
     {
-        $this->object
-            ->should_throw(new MatcherNotFoundException('crazy_alias'))
+        $this->object->shouldThrow(new MatcherNotFoundException('crazy_alias'))
             ->during('find', array('crazy_alias', 42, array()));
     }
 
     /**
      * @param ObjectStub $matcher mock of PHPSpec2\Matcher\MatcherInterface
      */
-    function will_complain_if_matcher_is_not_found($matcher)
+    function it_will_complain_if_matcher_is_not_found($matcher)
     {
         $this->object->add($matcher);
-        $this->object
-            ->should_throw('PHPSpec2\Exception\Example\MatcherNotFoundException')
+        $this->object->shouldThrow(new MatcherNotFoundException('crazy_alias'))
             ->during('find', array('crazy_alias', 42, array()));
     }
 
     /**
      * @param ObjectStub $matcher mock of PHPSpec2\Matcher\MatcherInterface
      */
-    function will_return_matcher_if_found($matcher)
+    function it_will_return_matcher_if_found($matcher)
     {
-        $matcher->supports('work', 42, array())->will_return(true);
+        $matcher->supports('work', 42, array())->willReturn(true);
 
         $this->object->add($matcher);
-        $this->object->find('work', 42, array())->should_equal($matcher);
+        $this->object->find('work', 42, array())->shouldBeEqualTo($matcher);
     }
 }

--- a/spec/PHPSpec2/Matcher/PredicateMatcher.php
+++ b/spec/PHPSpec2/Matcher/PredicateMatcher.php
@@ -11,7 +11,7 @@ class PredicateMatcher implements Specification
         $subject = new \ReflectionClass($this);
 
         // $subject->isAbstract(...)
-        $this->object->supports('be_abstract', $subject, array())->should_return_true();
+        $this->object->supports('be_abstract', $subject, array())->shouldReturnTrue();
     }
 
     function infers_matcher_alias_name_from_methods_prefixed_with_has()
@@ -19,7 +19,7 @@ class PredicateMatcher implements Specification
         $subject = new \ReflectionClass($this);
 
         // $subject->hasMethod(...)
-        $this->object->supports('have_method', $subject, array())->should_return_true();
+        $this->object->supports('have_method', $subject, array())->shouldReturnTrue();
     }
 
     function matches_is_method_against_true()
@@ -28,7 +28,7 @@ class PredicateMatcher implements Specification
         $this->object->supports('be_abstract', $subject, array());
 
         // $subject->isAbstract(...)
-        $this->object->should_throw('PHPSpec2\Exception\Example\FailureException')
+        $this->object->shouldThrow('PHPSpec2\Exception\Example\FailureException')
             ->during('positiveMatch', array('be_abstract', $subject, array()));
     }
 
@@ -36,9 +36,9 @@ class PredicateMatcher implements Specification
     {
         $subject = new \ReflectionClass($this);
         $this->object->supports('have_method', $subject, array());
-        
+
         // $subject->hasMethod(...)
-        $this->object->should_throw('PHPSpec2\Exception\Example\FailureException')
+        $this->object->shouldThrow('PHPSpec2\Exception\Example\FailureException')
             ->during('positiveMatch', array('have_method', $subject, array('unknown_method')));
     }
 }

--- a/spec/PHPSpec2/Matcher/PredicateMatcher.php
+++ b/spec/PHPSpec2/Matcher/PredicateMatcher.php
@@ -6,7 +6,7 @@ use PHPSpec2\Specification;
 
 class PredicateMatcher implements Specification
 {
-    function infers_matcher_alias_name_from_methods_prefixed_with_is()
+    function it_infers_matcher_alias_name_from_methods_prefixed_with_is()
     {
         $subject = new \ReflectionClass($this);
 
@@ -14,7 +14,7 @@ class PredicateMatcher implements Specification
         $this->object->supports('be_abstract', $subject, array())->shouldReturnTrue();
     }
 
-    function infers_matcher_alias_name_from_methods_prefixed_with_has()
+    function it_infers_matcher_alias_name_from_methods_prefixed_with_has()
     {
         $subject = new \ReflectionClass($this);
 
@@ -22,7 +22,7 @@ class PredicateMatcher implements Specification
         $this->object->supports('have_method', $subject, array())->shouldReturnTrue();
     }
 
-    function matches_is_method_against_true()
+    function it_matches_is_method_against_true()
     {
         $subject = new \ReflectionClass($this);
         $this->object->supports('be_abstract', $subject, array());
@@ -32,7 +32,7 @@ class PredicateMatcher implements Specification
             ->during('positiveMatch', array('be_abstract', $subject, array()));
     }
 
-    function matches_has_method_against_true()
+    function it_matches_has_method_against_true()
     {
         $subject = new \ReflectionClass($this);
         $this->object->supports('have_method', $subject, array());

--- a/spec/PHPSpec2/Matcher/ThrowMatcher.php
+++ b/spec/PHPSpec2/Matcher/ThrowMatcher.php
@@ -7,7 +7,7 @@ use stdClass;
 
 class ThrowMatcher implements Specification
 {
-    function supports_the_throw_alias_for_object_and_exception_name()
+    function it_supports_the_throw_alias_for_object_and_exception_name()
     {
         $this->object
             ->supports('throw', new stdClass, array('\Exception'))
@@ -17,7 +17,7 @@ class ThrowMatcher implements Specification
     /**
      * @param ObjectStub $subject mock of stdClass
      */
-    function can_specify_a_method_during_which_an_exception_should_be_throw($subject)
+    function it_can_specify_a_method_during_which_an_exception_should_be_throw($subject)
     {
         $subject->someMethod()
             ->willThrow('\Exception');
@@ -30,7 +30,7 @@ class ThrowMatcher implements Specification
     /**
      * @param ObjectStub $subject mock of stdClass
      */
-    function can_specify_a_method_during_which_an_exception_should_not_be_throw($subject)
+    function it_can_specify_a_method_during_which_an_exception_should_not_be_throw($subject)
     {
         $this->object
             ->negativeMatch('throw', $subject, array('\Exception'))

--- a/spec/PHPSpec2/Matcher/ThrowMatcher.php
+++ b/spec/PHPSpec2/Matcher/ThrowMatcher.php
@@ -11,7 +11,7 @@ class ThrowMatcher implements Specification
     {
         $this->object
             ->supports('throw', new stdClass, array('\Exception'))
-            ->should_return_true();
+            ->shouldReturnTrue();
     }
 
     /**
@@ -20,7 +20,7 @@ class ThrowMatcher implements Specification
     function can_specify_a_method_during_which_an_exception_should_be_throw($subject)
     {
         $subject->someMethod()
-            ->will_throw('\Exception');
+            ->willThrow('\Exception');
 
         $this->object
             ->positiveMatch('throw', $subject, array('\Exception'))

--- a/spec/PHPSpec2/Matcher/TrueMatcher.php
+++ b/spec/PHPSpec2/Matcher/TrueMatcher.php
@@ -6,7 +6,7 @@ use PHPSpec2\Specification;
 
 class TrueMatcher implements Specification
 {
-    function supports_useful_aliases()
+    function it_supports_useful_aliases()
     {
         $this->object->supports('beTrue', null, array())
                      ->shouldBeTrue();
@@ -15,37 +15,37 @@ class TrueMatcher implements Specification
                      ->shouldBeTrue();
     }
 
-    function complains_when_matching_anything_different_from_true()
+    function it_complains_when_matching_anything_different_from_true()
     {
-        foreach ($this->list_of_values_with_no_true() as $value) {
+        foreach ($this->listOfNotTrueValues() as $value) {
             $this->object->shouldThrow('PHPSpec2\Exception\Example\BooleanNotEqualException')
                  ->during('positiveMatch', array('be_true', $value, array()));
         }
     }
 
-    function does_not_complains_when_matching_true()
+    function it_does_not_complains_when_matching_true()
     {
         $this->trueMatcher->shouldNotThrow('PHPSpec2\Exception\Example\BooleanNotEqualException')
              ->during('positiveMatch', array('be_true', true, array()));
 
     }
 
-    function complains_when_reverse_matching_true()
+    function it_complains_when_reverse_matching_true()
     {
         $this->object->shouldThrow('PHPSpec2\Exception\Example\BooleanNotEqualException')
              ->during('negativeMatch', array('be_true', true, array()));
     }
 
-    function does_not_complains_when_reverse_matching_not_true()
+    function it_does_not_complains_when_reverse_matching_not_true()
     {
-        foreach ($this->list_of_values_with_no_true() as $value) {
+        foreach ($this->listOfNotTrueValues() as $value) {
             $this->object->shouldNotThrow('PHPSpec2\Exception\Example\BooleanNotEqualException')
                  ->during('negativeMatch', array('be_true', $value, array()));
         }
 
     }
 
-    private function list_of_values_with_no_true()
+    private function listOfNotTrueValues()
     {
         return array(
             1,

--- a/spec/PHPSpec2/Matcher/TrueMatcher.php
+++ b/spec/PHPSpec2/Matcher/TrueMatcher.php
@@ -8,41 +8,41 @@ class TrueMatcher implements Specification
 {
     function supports_useful_aliases()
     {
-        $this->object->supports('be_true', null, array())
-                     ->should_be_true();
-                     
-        $this->object->supports('return_true', null, array())
-                     ->should_be_true();
+        $this->object->supports('beTrue', null, array())
+                     ->shouldBeTrue();
+
+        $this->object->supports('returnTrue', null, array())
+                     ->shouldBeTrue();
     }
 
     function complains_when_matching_anything_different_from_true()
     {
         foreach ($this->list_of_values_with_no_true() as $value) {
-            $this->object->should_throw('PHPSpec2\Exception\Example\BooleanNotEqualException')
+            $this->object->shouldThrow('PHPSpec2\Exception\Example\BooleanNotEqualException')
                  ->during('positiveMatch', array('be_true', $value, array()));
         }
     }
 
     function does_not_complains_when_matching_true()
     {
-        $this->trueMatcher->should_not_throw('PHPSpec2\Exception\Example\BooleanNotEqualException')
+        $this->trueMatcher->shouldNotThrow('PHPSpec2\Exception\Example\BooleanNotEqualException')
              ->during('positiveMatch', array('be_true', true, array()));
-        
+
     }
 
     function complains_when_reverse_matching_true()
     {
-        $this->object->should_throw('PHPSpec2\Exception\Example\BooleanNotEqualException')
+        $this->object->shouldThrow('PHPSpec2\Exception\Example\BooleanNotEqualException')
              ->during('negativeMatch', array('be_true', true, array()));
     }
 
     function does_not_complains_when_reverse_matching_not_true()
     {
         foreach ($this->list_of_values_with_no_true() as $value) {
-            $this->object->should_not_throw('PHPSpec2\Exception\Example\BooleanNotEqualException')
+            $this->object->shouldNotThrow('PHPSpec2\Exception\Example\BooleanNotEqualException')
                  ->during('negativeMatch', array('be_true', $value, array()));
         }
-        
+
     }
 
     private function list_of_values_with_no_true()

--- a/spec/PHPSpec2/Mocker/MockerFactory.php
+++ b/spec/PHPSpec2/Mocker/MockerFactory.php
@@ -10,7 +10,7 @@ class MockerFactory implements Specification
     function creates_a_Mockery_Mocker_by_default()
     {
         $this->object->mock('PHPSpec2\Specification')
-            ->should_return_an_instance_of('PHPSpec2\Specification');
+            ->shouldReturnAnInstanceOf('PHPSpec2\Specification');
     }
 
     function can_mock_method_on_created_mock($resolver)
@@ -18,33 +18,33 @@ class MockerFactory implements Specification
         $mock = $this->object->mock('PHPSpec2\Specification');
 
         $mock->mockMethod('someMethid', array(), new ArgumentsResolver())
-            ->should_return_an_instance_of('PHPSpec2\Mocker\Mockery\ExpectationProxy');
+            ->shouldReturnAnInstanceOf('PHPSpec2\Mocker\Mockery\ExpectationProxy');
     }
 
     function can_be_created_with_an_alternative_mocker($mocker, $proxy)
     {
-        $proxy        ->is_a_mock_of('PHPSpec2\Mocker\MockProxyInterface');
-        $mocker       ->is_a_mock_of('PHPSpec2\Mocker\MockerInterface');
-        $this->object ->is_an_instance_of('PHPSpec2\Mocker\MockerFactory', array($mocker));
+        $proxy        ->isAMockOf('PHPSpec2\Mocker\MockProxyInterface');
+        $mocker       ->isAMockOf('PHPSpec2\Mocker\MockerInterface');
+        $this->object ->isAnInstanceOf('PHPSpec2\Mocker\MockerFactory', array($mocker));
 
         $mocker->mock('PHPSpec2\Specification')
-            ->will_return($proxy);
+            ->willReturn($proxy);
 
         $this->object->mock('PHPSpec2\Specification')
-            ->should_be_equal_to($proxy);
+            ->shouldBeEqualTo($proxy);
     }
 
     function can_be_created_with_later_configured_mocker($mocker, $proxy)
     {
-        $proxy  ->is_a_mock_of('PHPSpec2\Mocker\MockProxyInterface');
-        $mocker ->is_a_mock_of('PHPSpec2\Mocker\MockerInterface');
+        $proxy  ->isAMockOf('PHPSpec2\Mocker\MockProxyInterface');
+        $mocker ->isAMockOf('PHPSpec2\Mocker\MockerInterface');
 
         $this->object->setMocker($mocker);
 
         $mocker->mock('PHPSpec2\Specification')
-            ->will_return($proxy);
+            ->willReturn($proxy);
 
         $this->object->mock('PHPSpec2\Specification')
-            ->should_be_equal_to($proxy);
+            ->shouldBeEqualTo($proxy);
     }
 }

--- a/spec/PHPSpec2/Mocker/MockerFactory.php
+++ b/spec/PHPSpec2/Mocker/MockerFactory.php
@@ -7,13 +7,13 @@ use PHPSpec2\Stub\ArgumentsResolver;
 
 class MockerFactory implements Specification
 {
-    function creates_a_Mockery_Mocker_by_default()
+    function it_creates_a_Mockery_Mocker_by_default()
     {
         $this->object->mock('PHPSpec2\Specification')
             ->shouldReturnAnInstanceOf('PHPSpec2\Specification');
     }
 
-    function can_mock_method_on_created_mock($resolver)
+    function it_can_mock_method_on_created_mock($resolver)
     {
         $mock = $this->object->mock('PHPSpec2\Specification');
 
@@ -21,30 +21,26 @@ class MockerFactory implements Specification
             ->shouldReturnAnInstanceOf('PHPSpec2\Mocker\Mockery\ExpectationProxy');
     }
 
-    function can_be_created_with_an_alternative_mocker($mocker, $proxy)
+    function it_can_be_created_with_an_alternative_mocker($mocker, $proxy)
     {
-        $proxy        ->isAMockOf('PHPSpec2\Mocker\MockProxyInterface');
-        $mocker       ->isAMockOf('PHPSpec2\Mocker\MockerInterface');
-        $this->object ->isAnInstanceOf('PHPSpec2\Mocker\MockerFactory', array($mocker));
+        $proxy->isAMockOf('PHPSpec2\Mocker\MockProxyInterface');
+        $mocker->isAMockOf('PHPSpec2\Mocker\MockerInterface');
+        $this->object->isAnInstanceOf('PHPSpec2\Mocker\MockerFactory', array($mocker));
 
-        $mocker->mock('PHPSpec2\Specification')
-            ->willReturn($proxy);
+        $mocker->mock('PHPSpec2\Specification')->willReturn($proxy);
 
-        $this->object->mock('PHPSpec2\Specification')
-            ->shouldBeEqualTo($proxy);
+        $this->object->mock('PHPSpec2\Specification')->shouldBeEqualTo($proxy);
     }
 
-    function can_be_created_with_later_configured_mocker($mocker, $proxy)
+    function it_can_be_created_with_later_configured_mocker($mocker, $proxy)
     {
-        $proxy  ->isAMockOf('PHPSpec2\Mocker\MockProxyInterface');
-        $mocker ->isAMockOf('PHPSpec2\Mocker\MockerInterface');
+        $proxy->isAMockOf('PHPSpec2\Mocker\MockProxyInterface');
+        $mocker->isAMockOf('PHPSpec2\Mocker\MockerInterface');
 
         $this->object->setMocker($mocker);
 
-        $mocker->mock('PHPSpec2\Specification')
-            ->willReturn($proxy);
+        $mocker->mock('PHPSpec2\Specification')->willReturn($proxy);
 
-        $this->object->mock('PHPSpec2\Specification')
-            ->shouldBeEqualTo($proxy);
+        $this->object->mock('PHPSpec2\Specification')->shouldBeEqualTo($proxy);
     }
 }

--- a/src/PHPSpec2/Matcher/ComparisonMatcher.php
+++ b/src/PHPSpec2/Matcher/ComparisonMatcher.php
@@ -14,7 +14,7 @@ class ComparisonMatcher extends BasicMatcher
 {
     public function supports($name, $subject, array $arguments)
     {
-        return in_array($name, array('be_like'));
+        return in_array($name, array('beLike'));
     }
 
     protected function matches($subject, array $arguments)

--- a/src/PHPSpec2/Matcher/IdentityMatcher.php
+++ b/src/PHPSpec2/Matcher/IdentityMatcher.php
@@ -14,7 +14,7 @@ class IdentityMatcher extends BasicMatcher
 {
     public function supports($name, $subject, array $arguments)
     {
-        return in_array($name, array('return', 'be', 'equal', 'be_equal_to'));
+        return in_array($name, array('return', 'be', 'equal', 'beEqualTo'));
     }
 
     protected function matches($subject, array $arguments)

--- a/src/PHPSpec2/Matcher/TrueMatcher.php
+++ b/src/PHPSpec2/Matcher/TrueMatcher.php
@@ -12,7 +12,7 @@ class TrueMatcher extends BasicMatcher
     public function supports($name, $subject, array $arguments)
     {
         $this->usedAlias = $name;
-        return in_array($name, array('be_true', 'return_true'));
+        return in_array($name, array('beTrue', 'returnTrue'));
     }
 
     protected function matches($subject, array $arguments)

--- a/src/PHPSpec2/Matcher/TypeMatcher.php
+++ b/src/PHPSpec2/Matcher/TypeMatcher.php
@@ -8,7 +8,7 @@ class TypeMatcher extends BasicMatcher
 {
     public function supports($name, $subject, array $arguments)
     {
-        return in_array($name, array('be_an_instance_of', 'return_an_instance_of'));
+        return in_array($name, array('beAnInstanceOf', 'returnAnInstanceOf'));
     }
 
     protected function matches($subject, array $arguments)

--- a/src/PHPSpec2/Mocker/Mockery/ExpectationProxy.php
+++ b/src/PHPSpec2/Mocker/Mockery/ExpectationProxy.php
@@ -16,28 +16,28 @@ class ExpectationProxy
         $this->expectation = call_user_func_array(array($expectation, 'with'), $arguments);
         $this->resolver    = $resolver;
 
-        $this->should_be_called();
-        $this->will_return(null);
+        $this->shouldBeCalled();
+        $this->willReturn(null);
     }
 
-    public function will_return($value = null)
+    public function willReturn($value = null)
     {
         return call_user_func_array(
             array($this->expectation, 'andReturn'), $this->resolver->resolve($value)
         );
     }
 
-    public function should_be_called()
+    public function shouldBeCalled()
     {
         $this->expectation->atLeast(1);
     }
 
-    public function should_not_be_called()
+    public function shouldNotBeCalled()
     {
         $this->expectation->never();
     }
 
-    public function will_throw($exception, $message = '')
+    public function willThrow($exception, $message = '')
     {
         $this->expectation->andThrow($exception, $message);
     }

--- a/src/PHPSpec2/Stub/ObjectStub.php
+++ b/src/PHPSpec2/Stub/ObjectStub.php
@@ -29,12 +29,12 @@ class ObjectStub
         $this->resolver = $resolver ?: new ArgumentsResolver();
     }
 
-    public function is_an_instance_of($class, array $constructorArguments = array())
+    public function isAnInstanceOf($class, array $constructorArguments = array())
     {
         $this->subject = new LazyInstance($class, $this->resolver->resolve($constructorArguments));
     }
 
-    public function is_a_mock_of($classOrInterface)
+    public function isAMockOf($classOrInterface)
     {
         $this->subject = new LazyMock($classOrInterface, $this->mockers);
     }
@@ -44,7 +44,7 @@ class ObjectStub
         return new Verification\Positive($this->getStubSubject(), $this->matchers, $this->resolver);
     }
 
-    public function should_not()
+    public function shouldNot()
     {
         return new Verification\Negative($this->getStubSubject(), $this->matchers, $this->resolver);
     }
@@ -104,13 +104,13 @@ class ObjectStub
 
     public function __call($method, array $arguments = array())
     {
-        // if user calls function with should_ prefix - call matcher
-        if (preg_match('/^(should(?:_not|)?)_(.+)$/', $method, $matches)) {
-            $matcherName = $matches[2];
+        // if user calls function with should prefix - call matcher
+        if (preg_match('/^(should(?:Not|))(.+)$/', $method, $matches)) {
+            $matcherName = lcfirst($matches[2]);
             if ('should' === $matches[1]) {
                 return call_user_func_array(array($this->should(), $matcherName), $arguments);
             } else {
-                return call_user_func_array(array($this->should_not(), $matcherName), $arguments);
+                return call_user_func_array(array($this->shouldNot(), $matcherName), $arguments);
             }
         }
 

--- a/src/PHPSpec2/Tester.php
+++ b/src/PHPSpec2/Tester.php
@@ -87,8 +87,9 @@ class Tester
 
         $className = substr($spec->getName(), (int)strrpos($spec->getName(), '\\') + 1);
         $className = strtolower($className[0]) . substr($className, 1);
-        $instance->$className = new ObjectStub($subject, $this->matchers);
-        $instance->object = $instance->$className;
+
+        $stub = new ObjectStub($subject, $this->matchers);
+        $instance->$className = $instance->object = $stub;
 
         $stubs = $this->getStubsForExample($instance, $example);
 
@@ -197,7 +198,7 @@ class Tester
             if (preg_match('#^@param(?: *[^ ]*)? *\$([^ ]*) *mock of (.*)$#', $line, $match)) {
                 if (!isset($stubs[$match[1]])) {
                     $stubs[$match[1]] = new ObjectStub(null, $this->matchers);
-                    $stubs[$match[1]]->is_a_mock_of($match[2]);
+                    $stubs[$match[1]]->isAMockOf($match[2]);
                 }
             }
         }

--- a/src/PHPSpec2/Tester.php
+++ b/src/PHPSpec2/Tester.php
@@ -208,7 +208,7 @@ class Tester
 
     private function isExampleTestable(ReflectionMethod $example)
     {
-        return 'described_with' !== $example->getName();
+        return (bool) preg_match('/^(it_|its_)/', $example->getName());
     }
 
     private function specContainsFilteredExamples(array $examples)


### PR DESCRIPTION
As we've talked about during this week - switching matchers to camelCasing
Also, examples now should start with `it_` or `its_` prefix. This will make convention more explicit and examples more readable. Yeah, i know i was against it at the beginning. But after having couple of specs, i agree, that we need to distinguish examples from spec helpers and method accessibility is not enough here.
