### PR TITLE
Added missing parameter to MethodNotFoundException.

### DIFF
--- a/src/PHPSpec2/Stub/ObjectStub.php
+++ b/src/PHPSpec2/Stub/ObjectStub.php
@@ -70,7 +70,7 @@ class ObjectStub
             return $this->getStubSubject()->mockMethod($method, $arguments, $this->resolver);
         }
 
-        throw new MethodNotFoundException($method);
+        throw new MethodNotFoundException($this->getStubSubject(), $method);
     }
 
     public function setToStub($property, $value = null)


### PR DESCRIPTION
When creating an expectation for a new method and running PHPSpec, I get the following:

```
PHP Warning:  Missing argument 2 for 
PHPSpec2\Exception\Stub\MethodNotFoundException::__construct(), 
called in 
[...]/vendor/phpspec/phpspec2/src/PHPSpec2/Stub/ObjectStub.php 
on line 73 and defined in 
[...]/vendor/phpspec/phpspec2/src/PHPSpec2/Exception/Stub/MethodNotFoundException.php 
on line 7
```
