### PR TITLE
Rename DescribeCommand

### DIFF
--- a/src/PHPSpec2/Console/Command/DescribeCommand.php
+++ b/src/PHPSpec2/Console/Command/DescribeCommand.php
@@ -17,7 +17,7 @@ class DescribeCommand extends Command
      */
     public function __construct()
     {
-        parent::__construct('desc');
+        parent::__construct('describe');
 
         $this->setDefinition(array(
             new InputArgument('spec', InputArgument::REQUIRED, 'Spec to describe'),


### PR DESCRIPTION
Rename "desc" to "describe" as "desc" will still tricker the same
command because Symfony tries to find the best match. Fixes #20
