### PR TITLE
Implemented ArrayAccess for ObjectProphet, MockProphet and ObjectBehavior

### DIFF
--- a/spec/PHPSpec2/Prophet/ObjectProphet.php
+++ b/spec/PHPSpec2/Prophet/ObjectProphet.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace spec\PHPSpec2\Prophet;
+
+use PHPSpec2\ObjectBehavior;
+
+class ObjectProphet extends ObjectBehavior
+{
+    /**
+     * @param \ArrayAccess                         $subject
+     * @param \PHPSpec2\Matcher\MatchersCollection $matchersCollection
+     * @param \PHPSpec2\Wrapper\ArgumentsUnwrapper $unwrapper
+     */
+    function let($subject, $matchersCollection, $unwrapper)
+    {
+        $this->beConstructedWith($subject, $matchersCollection, $unwrapper);
+    }
+
+    function it_supports_get_array_access($subject)
+    {
+        $subject['foo']->willReturn('bar');
+
+        $this['foo']->shouldReturn('bar');
+    }
+
+    function it_supports_set_array_access($subject)
+    {
+        $subject->offsetSet('foo', 'bar')->shouldBeCalled();
+
+        $this['foo'] = 'bar';
+    }
+
+    function it_supports_exists_array_access($subject)
+    {
+        $subject->offsetExists('foo')->willReturn(true)->shouldBeCalled();
+
+        $this->offsetExists('foo')->shouldReturn(true);
+    }
+
+    function it_supports_unset_array_access($subject)
+    {
+        $subject->offsetUnset('foo')->shouldBeCalled();
+
+        unset($this['foo']);
+    }
+}

--- a/src/PHPSpec2/ObjectBehavior.php
+++ b/src/PHPSpec2/ObjectBehavior.php
@@ -2,10 +2,12 @@
 
 namespace PHPSpec2;
 
+use ArrayAccess;
+
 use PHPSpec2\Prophet\ProphetInterface;
 use PHPSpec2\Wrapper\SubjectWrapperInterface;
 
-class ObjectBehavior implements SpecificationInterface, SubjectWrapperInterface
+class ObjectBehavior implements SpecificationInterface, SubjectWrapperInterface, ArrayAccess
 {
     protected $object;
 
@@ -17,6 +19,26 @@ class ObjectBehavior implements SpecificationInterface, SubjectWrapperInterface
     public function getWrappedSubject()
     {
         return $this->object;
+    }
+
+    public function offsetExists($offset)
+    {
+        return $this->object->offsetExists($offset);
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->object->offsetGet($offset);
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        $this->object->offsetSet($offset, $value);
+    }
+
+    public function offsetUnset($offset)
+    {
+        return $this->object->offsetUnset($offset);
     }
 
     public function __call($method, array $arguments = array())

--- a/src/PHPSpec2/Prophet/MockProphet.php
+++ b/src/PHPSpec2/Prophet/MockProphet.php
@@ -2,12 +2,14 @@
 
 namespace PHPSpec2\Prophet;
 
+use ArrayAccess;
+
 use PHPSpec2\Mocker\MockerInterface;
 use PHPSpec2\Mocker\MockExpectation;
 
 use PHPSpec2\Wrapper\ArgumentsUnwrapper;
 
-class MockProphet implements ProphetInterface
+class MockProphet implements ProphetInterface, ArrayAccess
 {
     private $subject;
     private $mocker;
@@ -24,6 +26,26 @@ class MockProphet implements ProphetInterface
     public function beAMockOf($classOrInterface)
     {
         $this->subject = $this->mocker->mock($classOrInterface);
+    }
+
+    public function offsetExists($offset)
+    {
+        return call_user_func_array($this->offsetExists, array($offset));
+    }
+
+    public function offsetGet($offset)
+    {
+        return call_user_func_array($this->offsetGet, array($offset));
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        return call_user_func_array($this->offsetSet, array($offset, $value));
+    }
+
+    public function offsetUnset($offset)
+    {
+        return call_user_func_array($this->offsetUnset, array($offset));
     }
 
     public function __get($method)

--- a/src/PHPSpec2/Prophet/ObjectProphet.php
+++ b/src/PHPSpec2/Prophet/ObjectProphet.php
@@ -2,6 +2,8 @@
 
 namespace PHPSpec2\Prophet;
 
+use ArrayAccess;
+
 use ReflectionMethod;
 use ReflectionProperty;
 
@@ -18,7 +20,7 @@ use PHPSpec2\Exception\BehaviorException;
 use PHPSpec2\Exception\MethodNotFoundException;
 use PHPSpec2\Exception\PropertyNotFoundException;
 
-class ObjectProphet implements ProphetInterface
+class ObjectProphet implements ProphetInterface, ArrayAccess
 {
     private $subject;
     private $matchers;
@@ -167,6 +169,26 @@ class ObjectProphet implements ProphetInterface
         }
 
         return $this->subject;
+    }
+
+    public function offsetExists($offset)
+    {
+        return $this->callOnProphetSubject('offsetExists', array($offset));
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->callOnProphetSubject('offsetGet', array($offset));
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        return $this->callOnProphetSubject('offsetSet', array($offset, $value));
+    }
+
+    public function offsetUnset($offset)
+    {
+        return $this->callOnProphetSubject('offsetUnset', array($offset));
     }
 
     public function __call($method, array $arguments = array())


### PR DESCRIPTION
Refers to #27. 

It's hard to use PHPSpec to state expectations for itself since the subjects under specification is also the one used to specify (chicken and egg problem)...
