### PR TITLE
Add .gitattributes for consistent line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.php text eol=lf


### PR DESCRIPTION
Fixes a fatal error when running specs in windows.

PHPSpec2\Runner\Runner::getDependencies() does not behave correctly if files are CRLF: MockProphets created from doc blocks are not indexed under the same name as their parameter counterparts.

Rather than adding code to handle this case, I've added a .gitattributes to ensure that windows users will checkout php files with the correct line endings.

More info here https://help.github.com/articles/dealing-with-line-endings
