### PR TITLE
Fixed retrieving of a new subject instance via LazyObject.

### DIFF
--- a/src/PHPSpec2/Subject/LazyObject.php
+++ b/src/PHPSpec2/Subject/LazyObject.php
@@ -57,6 +57,10 @@ class LazyObject implements LazySubjectInterface
 
         $reflection = new ReflectionClass($this->classname);
 
-        return $this->instance = $reflection->newInstanceArgs($this->arguments);
+        if (!empty($this->arguments)) {
+            return $this->instance = $reflection->newInstanceArgs($this->arguments);
+        }
+
+        return $this->instance = $reflection->newInstance();
     }
 }


### PR DESCRIPTION
Calling ReflectionClass::newInstanceArgs() with an empty array fails on older PHP versions (confirmed failing on PHP 5.3.3).
