### PR TITLE
Print the location where the class/spec have been created.

### DIFF
--- a/src/PHPSpec2/Listener/ClassNotFoundListener.php
+++ b/src/PHPSpec2/Listener/ClassNotFoundListener.php
@@ -52,7 +52,7 @@ class ClassNotFoundListener implements EventSubscriberInterface
                 file_put_contents($filepath, $this->getClassContentFor($classname));
 
                 $this->io->writeln(sprintf(
-                    "\n<info>class <value>%s</value> has been created.</info>", $classname
+                    "\n<info>class <value>%s</value> has been created at \"" . $filepath . "\".</info>", $classname
                 ), 6);
             }
 

--- a/src/PHPSpec2/Listener/ClassNotFoundListener.php
+++ b/src/PHPSpec2/Listener/ClassNotFoundListener.php
@@ -52,7 +52,7 @@ class ClassNotFoundListener implements EventSubscriberInterface
                 file_put_contents($filepath, $this->getClassContentFor($classname));
 
                 $this->io->writeln(sprintf(
-                    "\n<info>class <value>%s</value> has been created at \"" . $filepath . "\".</info>", $classname
+                    "\n<info>Class <value>%s</value> has been created at <value>" . $filepath . "</value>.</info>", $classname
                 ), 6);
             }
 


### PR DESCRIPTION
By suggestion of Johannes print the full path to the class/spec when
it is created by the script.

The convention is nice but displaying it will help people getting less
confused.

Fixes GH-47
