### PR TITLE
Final part of extension system - configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     "require": {
         "php":                      ">=5.3.1",
         "symfony/console":          ">=2.1.0,<2.2.0",
+        "symfony/yaml":             ">=2.1.0,<2.2.0",
         "symfony/event-dispatcher": ">=2.1.0,<2.2.0",
         "symfony/finder":           ">=2.1.0,<2.2.0",
         "mockery/mockery":          "0.7.*",

--- a/spec/PHPSpec2/Extension/Configuration.php
+++ b/spec/PHPSpec2/Extension/Configuration.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace spec\PHPSpec2\Extension;
+
+use PHPSpec2\ObjectBehavior;
+
+class Configuration extends ObjectBehavior
+{
+    /**
+     * @param PHPSpec2\ServiceContainer     $container
+     * @param PHPSpec2\Extension\YamlParser $parser
+     */
+    function let($container, $parser)
+    {
+        $this->beConstructedWith($container, $parser);
+    }
+
+    function it_should_set_parameters_from_config($container, $parser)
+    {
+        $parser->parse('phpspec.yml')->willReturn(array(
+            'some' => array(
+                'deep' => array(
+                    'parameter' => false
+                )
+            ),
+            'some.simple.parameter' => 123,
+            'some_array' => array(1, 2, 3)
+        ));
+
+        $container->set('some', array('deep' => array('parameter' => false)))->shouldBeCalled();
+        $container->set('some.simple.parameter', 123)->shouldBeCalled();
+        $container->set('some_array', array(1, 2, 3))->shouldBeCalled();
+
+        $this->read('phpspec.yml');
+    }
+}

--- a/spec/PHPSpec2/ServiceContainer.php
+++ b/spec/PHPSpec2/ServiceContainer.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace spec\PHPSpec2;
+
+use PHPSpec2\ObjectBehavior;
+
+class ServiceContainer extends ObjectBehavior
+{
+    function it_should_be_able_to_set_simple_parameters()
+    {
+        $this->set('param', 'test#value');
+        $this->get('param')->shouldReturn('test#value');
+    }
+
+    function it_should_be_able_to_set_array_parameters()
+    {
+        $this->set('param', array('test#value'));
+        $this->get('param')->shouldReturn(array('test#value'));
+    }
+
+    /**
+     * @param stdClass $service
+     */
+    function it_should_be_able_to_set_services($service)
+    {
+        $this->set('service', $service);
+        $this->get('service')->shouldReturn($service);
+    }
+
+    function it_should_return_true_for_existing_parameters()
+    {
+        $this->set('param1', true);
+        $this->has('param1')->shouldReturn(true);
+    }
+
+    function it_should_return_false_for_non_existing_parameters()
+    {
+        $this->has('unexisting')->shouldReturn(false);
+    }
+
+    function it_should_throw_exception_when_trying_to_get_unexisting_parameter()
+    {
+        $this->shouldThrow('InvalidArgumentException')->duringGet('unexisting');
+    }
+
+    /**
+     * @param stdClass $service
+     */
+    function it_should_build_services_through_factories($service)
+    {
+        $this->set('service', function() use($service) {
+            return $service->getWrappedSubject();
+        });
+        $this->get('service')->shouldReturn($service);
+    }
+
+    function it_should_be_able_to_remove_existing_parameters()
+    {
+        $this->set('param', true);
+        $this->remove('param');
+        $this->has('param')->shouldReturn(false);
+    }
+
+    function it_should_extend_collections()
+    {
+        $this->set('collection', array());
+        $this->extend('collection', 'item1');
+        $this->extend('collection', 'item2');
+
+        $this->get('collection')->shouldReturn(array('item1', 'item2'));
+    }
+
+    function it_should_resolve_factory_collections()
+    {
+        $this->set('collection', array());
+        $this->extend('collection', function() { return 'item1'; });
+        $this->extend('collection', function() { return 'item2'; });
+
+        $this->get('collection')->shouldReturn(array('item1', 'item2'));
+    }
+
+    function it_should_be_invokable()
+    {
+        $this('param', 'test#param');
+        $this('param')->shouldReturn('test#param');
+    }
+
+    function it_should_implement_array_access()
+    {
+        $this->shouldHaveType('ArrayAccess');
+    }
+}

--- a/src/PHPSpec2/Console/Application.php
+++ b/src/PHPSpec2/Console/Application.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
+use PHPSpec2\ServiceContainer;
 use PHPSpec2\Console;
 use PHPSpec2\Loader;
 use PHPSpec2\Runner;
@@ -19,13 +20,9 @@ use PHPSpec2\Wrapper\ArgumentsUnwrapper;
 use PHPSpec2\Prophet\DefaultSubjectGuesser;
 use PHPSpec2\Initializer;
 
-use ArrayAccess;
-use Closure;
-use InvalidArgumentException;
-
-class Application extends BaseApplication implements ArrayAccess, ExtendableApplicationInterface
+class Application extends BaseApplication
 {
-    private $items;
+    private $container;
 
     /**
      * {@inheritdoc}
@@ -34,158 +31,162 @@ class Application extends BaseApplication implements ArrayAccess, ExtendableAppl
     {
         parent::__construct('PHPSpec2', $version);
 
-        $this['parameters.format'] = 'progress';
+        $this->container = $c = new ServiceContainer;
 
-        $this['console.commands'] = array();
-        $this['io'] = $this->share(function($c) {
+        $c->set('parameters.format', 'progress');
+
+        $c->set('console.commands', array());
+        $c->set('io', $c->share(function($c) {
             return new Console\IO(
-                $c['console.input'],
-                $c['console.output'],
-                $c['console.helpers']
+                $c('console.input'),
+                $c('console.output'),
+                $c('console.helpers')
             );
-        });
+        }));
 
-        $this['event_dispatcher.listeners'] = array();
-        $this['event_dispatcher'] = $this->share(function($c) {
+        $c->set('event_dispatcher.listeners', array());
+        $c->set('event_dispatcher', $c->share(function($c) {
             $dispatcher = new EventDispatcher;
 
-            foreach ($c['event_dispatcher.listeners'] as $listener) {
+            foreach ($c('event_dispatcher.listeners') as $listener) {
                 $dispatcher->addSubscriber($listener);
             }
 
             return $dispatcher;
-        });
+        }));
 
-        $this['differ.engines'] = array();
-        $this['differ'] = function($c) {
+        $c->set('differ.engines', array());
+        $c->set('differ', function($c) {
             $differ = new Presenter\Differ\Differ;
 
-            foreach ($c['differ.engines'] as $engine) {
+            foreach ($c('differ.engines') as $engine) {
                 $differ->addEngine($engine);
             }
 
             return $differ;
-        };
+        });
 
-        $this->extend('differ.engines',
-            $this['differ.engines.string'] = $this->share(function($c) {
+        $c->extend('differ.engines',
+            $c->set('differ.engines.string', $c->share(function($c) {
                 return new Presenter\Differ\StringEngine;
-            })
+            }))
         );
 
-        $this['value_presenter'] = $this->share(function($c) {
-            return new Presenter\TaggedPresenter($c['differ']);
-        });
+        $c->set('value_presenter', $c->share(function($c) {
+            return new Presenter\TaggedPresenter($c('differ'));
+        }));
 
-        $this['mocker'] = $this->share(function($c) {
+        $c->set('mocker', $c->share(function($c) {
             return new Mocker\MockeryMocker;
-        });
+        }));
 
-        $this['arguments_unwrapper'] = $this->share(function($c) {
+        $c->set('arguments_unwrapper', $c->share(function($c) {
             return new ArgumentsUnwrapper;
-        });
+        }));
 
-        $this->extend('event_dispatcher.listeners',
-            $this['statistics_collector'] = $this->share(function($c) {
+        $c->extend('event_dispatcher.listeners',
+            $c->set('statistics_collector', $c->share(function($c) {
                 return new Listener\StatisticsCollector;
-            })
+            }))
         );
 
-        $this->extend('event_dispatcher.listeners',
-            $this['formatter'] = $this->share(function($c) {
-                if ('progress' === $c['parameters.format']) {
+        $c->extend('event_dispatcher.listeners',
+            $c->set('formatter', $c->share(function($c) {
+                if ('progress' === $c('parameters.format')) {
                     $formatter = new Formatter\ProgressFormatter;
                 } else {
                     $formatter = new Formatter\PrettyFormatter;
                 }
 
-                $formatter->setIO($c['io']);
-                $formatter->setPresenter($c['value_presenter']);
-                $formatter->setStatisticsCollector($c['statistics_collector']);
+                $formatter->setIO($c('io'));
+                $formatter->setPresenter($c('value_presenter'));
+                $formatter->setStatisticsCollector($c('statistics_collector'));
 
                 return $formatter;
-            })
+            }))
         );
 
-        $this['specifications_loader'] = $this->share(function($c) {
+        $c->set('specifications_loader', $c->share(function($c) {
             return new Loader\SpecificationsClassLoader;
-        });
+        }));
 
-        $this['locator'] = $this->share(function($c) {
-            return new Runner\Locator($c['specifications_loader']);
-        });
+        $c->set('locator', $c->share(function($c) {
+            return new Runner\Locator($c('specifications_loader'));
+        }));
 
-        $this['runner.subject_guessers'] = array();
-        $this['runner.specification_initializers'] = array();
-        $this['runner.example_initializers'] = array();
-        $this['runner'] = $this->share(function($c) {
+        $c->set('runner.subject_guessers', array());
+        $c->set('runner.specification_initializers', array());
+        $c->set('runner.example_initializers', array());
+
+        $c->set('runner', $c->share(function($c) {
             $runner = new Runner\Runner(
-                $c['event_dispatcher'],
-                $c['mocker']
+                $c('event_dispatcher'),
+                $c('mocker')
             );
 
-            foreach ($c['runner.subject_guessers'] as $guesser) {
+            foreach ($c('runner.subject_guessers') as $guesser) {
                 $runner->registerSubjectGuesser($guesser);
             }
-            foreach ($c['runner.specification_initializers'] as $initializer) {
+            foreach ($c('runner.specification_initializers') as $initializer) {
                 $runner->registerSpecificationInitializer($initializer);
             }
-            foreach ($c['runner.example_initializers'] as $initializer) {
+            foreach ($c('runner.example_initializers') as $initializer) {
                 $runner->registerExampleInitializer($initializer);
             }
 
             return $runner;
+        }));
+
+        $c->extend('runner.subject_guessers', function($c) {
+            return new DefaultSubjectGuesser($c('arguments_unwrapper'));
         });
 
-        $this->extend('runner.subject_guessers', function($c) {
-            return new DefaultSubjectGuesser($c['arguments_unwrapper']);
-        });
-
-        $this->extend('runner.specification_initializers', function($c) {
+        $c->extend('runner.specification_initializers', function($c) {
             return new Initializer\DefaultMatchersInitializer(
-                $c['value_presenter'],
-                $c['arguments_unwrapper']
+                $c('value_presenter'),
+                $c('arguments_unwrapper')
             );
         });
 
-        $this->extend('runner.specification_initializers', function($c) {
+        $c->extend('runner.specification_initializers', function($c) {
             return new Initializer\CustomMatchersInitializer(
-                $c['value_presenter'],
-                $c['arguments_unwrapper']
+                $c('value_presenter'),
+                $c('arguments_unwrapper')
             );
         });
 
-        $this->extend('runner.example_initializers', function($c) {
+        $c->extend('runner.example_initializers', function($c) {
             return new Initializer\ArgumentsProphetsInitializer(
-                $c['initializer.function_parameters_reader'],
-                $c['mocker'],
-                $c['arguments_unwrapper']
+                $c('initializer.function_parameters_reader'),
+                $c('mocker'),
+                $c('arguments_unwrapper')
             );
         });
 
-        $this['initializer.function_parameters_reader'] = function($c) {
+        $c->set('initializer.function_parameters_reader', function($c) {
             return new Initializer\FunctionParametersReader;
-        };
-
-        $this->extend('event_dispatcher.listeners', function($c) {
-            return new Listener\ClassNotFoundListener($c['io']);
         });
 
-        $this->extend('event_dispatcher.listeners', function($c) {
-            return new Listener\MethodNotFoundListener($c['io']);
+        $c->extend('event_dispatcher.listeners', function($c) {
+            return new Listener\ClassNotFoundListener($c('io'));
         });
 
-        $this->extend('console.commands', function($c) {
+        $c->extend('event_dispatcher.listeners', function($c) {
+            return new Listener\MethodNotFoundListener($c('io'));
+        });
+
+        $c->extend('console.commands', function($c) {
             return new Command\RunCommand;
         });
 
-        $this->extend('console.commands', function($c) {
+        $c->extend('console.commands', function($c) {
             return new Command\DescribeCommand;
         });
+    }
 
-        foreach ($this['console.commands'] as $command) {
-            $this->add($command);
-        }
+    public function getContainer()
+    {
+        return $this->container;
     }
 
     /**
@@ -193,70 +194,16 @@ class Application extends BaseApplication implements ArrayAccess, ExtendableAppl
      */
     public function doRun(InputInterface $input, OutputInterface $output)
     {
+        // TODO: read configuration here
+
+        foreach ($this->container->get('console.commands') as $command) {
+            $this->add($command);
+        }
+
         if (!($name = $this->getCommandName($input))) {
             $input = new ArrayInput(array('command' => 'run'));
         }
 
         parent::doRun($input, $output);
-    }
-
-    public function offsetSet($id, $value)
-    {
-        $this->items[$id] = $value;
-    }
-
-    public function offsetGet($id)
-    {
-        if (!$this->offsetExists($id)) {
-            throw new InvalidArgumentException(sprintf(
-                "Service/Parameter `%s` not found.", $id
-            ));
-        }
-
-        $value = $this->items[$id];
-
-        if (is_array($value)) {
-            return array_map(array($this, 'unwrapItem'), $value);
-        }
-
-        return $this->unwrapItem($value);
-    }
-
-    public function extend($id, $value)
-    {
-        if (!$this->offsetExists($id)) {
-            $this->items[$id] = array();
-        }
-
-        $this->items[$id][] = $value;
-    }
-
-    public function unwrapItem($value)
-    {
-        return $value instanceof Closure ? $value($this) : $value;
-    }
-
-    public function offsetExists($id)
-    {
-        return isset($this->items[$id]);
-    }
-
-    public function offsetUnset($id)
-    {
-        if (!$this->offsetExists($id)) {
-            throw new InvalidArgumentException(sprintf(
-                "Service/Parameter `%s` not found.", $id
-            ));
-        }
-
-        unset($this->items[$id]);
-    }
-
-    public function share(Closure $factory)
-    {
-        return function($c) use($factory) {
-            static $object;
-            return $object ?: $object = $factory($c);
-        };
     }
 }

--- a/src/PHPSpec2/Console/Command/RunCommand.php
+++ b/src/PHPSpec2/Console/Command/RunCommand.php
@@ -34,22 +34,22 @@ class RunCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $output->setFormatter(new Console\Formatter($output->isDecorated()));
-        $app = $this->getApplication();
+        $c = $this->getApplication()->getContainer();
 
-        $app['console.input']   = $input;
-        $app['console.output']  = $output;
-        $app['console.helpers'] = $this->getHelperSet();
+        $c->set('console.input', $input);
+        $c->set('console.output', $output);
+        $c->set('console.helpers', $this->getHelperSet());
 
-        $specs = $app['locator']->getSpecifications($input->getArgument('spec'));
-        $app['event_dispatcher']->dispatch('beforeSuite', new Event\SuiteEvent);
+        $specs = $c('locator')->getSpecifications($input->getArgument('spec'));
+        $c('event_dispatcher')->dispatch('beforeSuite', new Event\SuiteEvent);
 
         $result = 0;
         $startTime = microtime(true);
         foreach ($specs as $spec) {
-            $result = max($result, $app['runner']->runSpecification($spec));
+            $result = max($result, $c('runner')->runSpecification($spec));
         }
 
-        $app['event_dispatcher']->dispatch('afterSuite', new Event\SuiteEvent(
+        $c('event_dispatcher')->dispatch('afterSuite', new Event\SuiteEvent(
             microtime(true) - $startTime, $result
         ));
 

--- a/src/PHPSpec2/Console/ExtendableApplicationInterface.php
+++ b/src/PHPSpec2/Console/ExtendableApplicationInterface.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace PHPSpec2\Console;
-
-interface ExtendableApplicationInterface
-{
-    public function extend($id, $value);
-}

--- a/src/PHPSpec2/Extension/Configuration.php
+++ b/src/PHPSpec2/Extension/Configuration.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace PHPSpec2\Extension;
+
+use PHPSpec2\ServiceContainer;
+
+class Configuration
+{
+    private $container;
+
+    public function __construct(ServiceContainer $container, YamlParser $parser = null)
+    {
+        $this->container = $container;
+        $this->parser    = $parser ?: new YamlParser;
+    }
+
+    public function read($file)
+    {
+        if ($config = $this->parser->parse($file)) {
+            foreach ($config as $key => $val) {
+                $this->container->set($key, $val);
+            }
+        }
+    }
+}

--- a/src/PHPSpec2/Extension/ExtensionInterface.php
+++ b/src/PHPSpec2/Extension/ExtensionInterface.php
@@ -6,5 +6,5 @@ use PHPSpec2\ServiceContainer;
 
 interface ExtensionInterface
 {
-    public function initialize(ServiceContainer $container);
+    public function initialize(ServiceContainer $container, array $config);
 }

--- a/src/PHPSpec2/Extension/ExtensionInterface.php
+++ b/src/PHPSpec2/Extension/ExtensionInterface.php
@@ -2,9 +2,9 @@
 
 namespace PHPSpec2\Extension;
 
-use PHPSpec2\Console;
+use PHPSpec2\ServiceContainer;
 
 interface ExtensionInterface
 {
-    public function initialize(ExtendableApplicationInterface $application);
+    public function initialize(ServiceContainer $container);
 }

--- a/src/PHPSpec2/Extension/ExtensionInterface.php
+++ b/src/PHPSpec2/Extension/ExtensionInterface.php
@@ -6,5 +6,5 @@ use PHPSpec2\ServiceContainer;
 
 interface ExtensionInterface
 {
-    public function initialize(ServiceContainer $container, array $config);
+    public function initialize(ServiceContainer $container);
 }

--- a/src/PHPSpec2/Extension/YamlParser.php
+++ b/src/PHPSpec2/Extension/YamlParser.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace PHPSpec2\Extension;
+
+use Symfony\Component\Yaml\Yaml;
+
+class YamlParser
+{
+    public function parse($file)
+    {
+        return Yaml::parse($file);
+    }
+}

--- a/src/PHPSpec2/ObjectBehavior.php
+++ b/src/PHPSpec2/ObjectBehavior.php
@@ -33,4 +33,9 @@ class ObjectBehavior implements SpecificationInterface, SubjectWrapperInterface
     {
         return $this->object->$property;
     }
+
+    public function __invoke()
+    {
+        return call_user_func_array(array($this->object, '__invoke'), func_get_args());
+    }
 }

--- a/src/PHPSpec2/Prophet/ObjectProphet.php
+++ b/src/PHPSpec2/Prophet/ObjectProphet.php
@@ -184,6 +184,11 @@ class ObjectProphet implements ProphetInterface
         return $this->callOnProphetSubject($method, $arguments);
     }
 
+    public function __invoke()
+    {
+        return $this->callOnProphetSubject('__invoke', func_get_args());
+    }
+
     public function __set($property, $value = null)
     {
         return $this->setToProphetSubject($property, $value);

--- a/src/PHPSpec2/ServiceContainer.php
+++ b/src/PHPSpec2/ServiceContainer.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace PHPSpec2;
+
+use Closure;
+use ArrayAccess;
+use InvalidArgumentException;
+
+class ServiceContainer implements ArrayAccess
+{
+    private $values = array();
+
+    public function has($id)
+    {
+        return isset($this->values[$id]);
+    }
+
+    public function get($id)
+    {
+        if (!$this->has($id)) {
+            throw new InvalidArgumentException(sprintf(
+                "Service/Parameter `%s` not found.", $id
+            ));
+        }
+
+        $value = $this->values[$id];
+
+        if (is_array($value)) {
+            return array_map(array($this, 'unwrapItem'), $value);
+        }
+
+        return $this->unwrapItem($value);
+    }
+
+    public function set($id, $value)
+    {
+        return $this->values[$id] = $value;
+    }
+
+    public function remove($id)
+    {
+        unset($this->values[$id]);
+    }
+
+    public function extend($id, $extension)
+    {
+        if (!$this->has($id)) {
+            throw new InvalidArgumentException(sprintf(
+                "Service collection `%s` not defined.", $id
+            ));
+        }
+
+        $value = (array) $this->values[$id];
+        $value[] = $extension;
+
+        $this->values[$id] = $value;
+    }
+
+    public function share(Closure $factory)
+    {
+        return function($c) use($factory) {
+            static $object;
+            return $object ?: $object = $factory($c);
+        };
+    }
+
+    public function offsetExists($id)
+    {
+        return $this->has($id);
+    }
+
+    public function offsetSet($id, $value)
+    {
+        $this->set($id, $value);
+    }
+
+    public function offsetGet($id)
+    {
+        $this->get($id);
+    }
+
+    public function offsetUnset($id)
+    {
+        $this->remove($id);
+    }
+
+    public function __invoke($id, $value = null)
+    {
+        if (null === $value) {
+            return $this->get($id);
+        }
+
+        $this->set($id, $value);
+    }
+
+    private function unwrapItem($value)
+    {
+        return $value instanceof Closure ? $value($this) : $value;
+    }
+}


### PR DESCRIPTION
I've splitted container into separate clean object and implemented simple config reader with extensions support.

The way it works is very simple - phpspec2 has it's own ServiceContainer. Whole application class tree lives inside this container and extension system just exposes this container to your custom extension class.

All you need to do is to create custom class, implement `PHPSpec2\Extension\ExtensionInterface` with it:

``` php
<?php

namespace Your\Custom;

use PHPSpec2\Extension\ExtensionInterface;
use PHPSpec2\ServiceContainer;

class Extension implements ExtensionInterface
{
    public function initialize(ServiceContainer $c)
    {
        $c->set('format', 'pretty');

        $c->extend('specification_initializers', function($c) {
            return new CustomSpecInitializer();
        });
    }
}
```

and enable it inside `phpspec.yml`:

``` yaml
extensions:
    - Your\Custom\Extension
```
