### PR TITLE
add bootstrap option

### DIFF
--- a/src/PHPSpec2/Console/Application.php
+++ b/src/PHPSpec2/Console/Application.php
@@ -238,28 +238,30 @@ class Application extends BaseApplication
         
         // bootstrap
         
+        $has_param = $input->getParameterOption('--bootstrap'); 
+        
         // incorrect parameter
-        if(is_null($input->getParameterOption('--bootstrap'))) {
+        if(is_null($has_param)) {
             throw new InvalidArgumentException('The --bootstrap option needs a value');
         }
         
-        // get bootstrap file
-        $file = $input->getParameterOption('--bootstrap');
-        
-        if(!$file && $this->container->has("bootstrap")){
+        if(!$has_param && $this->container->has("bootstrap")){
             $file = $this->container->get("bootstrap");
+        }
+        else{
+            $file = $has_param;
         }
         
         if($file){
-            $file = realpath($file);
+            $realfile = realpath($file);
             
-            if(!is_file($file)){
+            if(!is_file($realfile)){
                 throw new InvalidArgumentException("The bootstrap file ({$file}) doesn't exist");
             }  
-            elseif(pathinfo($file, PATHINFO_EXTENSION) !== "php"){
+            elseif(pathinfo($realfile, PATHINFO_EXTENSION) !== "php"){
                 throw new InvalidArgumentException("The bootstrap file ({$file}) isn't a valid php file");
             } 
-            else require $file;
+            else require $realfile;
         }
         // end bootstap
 

--- a/src/PHPSpec2/Console/Command/RunCommand.php
+++ b/src/PHPSpec2/Console/Command/RunCommand.php
@@ -13,6 +13,8 @@ use PHPSpec2\Event;
 use PHPSpec2\Console;
 use PHPSpec2\Formatter;
 
+use InvalidArgumentException;
+
 class RunCommand extends Command
 {
     /**
@@ -25,6 +27,7 @@ class RunCommand extends Command
         $this->setDefinition(array(
             new InputArgument('spec', InputArgument::OPTIONAL, 'Specs to run', 'spec'),
             new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Formatter', 'progress'),
+            new InputOption('bootstrap', null, InputOption::VALUE_REQUIRED, 'Run a bootstrap file before start', false)
         ));
     }
 
@@ -33,6 +36,20 @@ class RunCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        if ($bootstrap = $input->getOption("bootstrap") ) {
+            if (null === $bootstrap) {
+                throw new InvalidArgumentException('The --bootstrap option needs a value');
+            }
+
+            if (!is_file($bootstrap)) {
+                throw new InvalidArgumentException("The bootstrap file ({$bootstrap}) doesn't exist");
+            } else if (pathinfo($bootstrap, PATHINFO_EXTENSION) !== "php") {
+                throw new InvalidArgumentException("The bootstrap file ({$bootstrap}) isn't a valid php file");
+            }
+
+            require $bootstrap;
+        }
+
         $output->setFormatter(new Console\Formatter($output->isDecorated()));
         $c = $this->getApplication()->getContainer();
 


### PR DESCRIPTION
Added the bootstrap option (issue #52)

After looking the issue and the tips on the pull request 64. I did quickly this peace of code and added this feature:
- if you add a file called bootstrap.php to the test folder, it will be automatically loaded;
- Exceptions will be raised if you pass a invalid, inexistent or not pass any file (only --bootstrap without the /path/to/file.php)

TODO: read the yaml file for a possible bootstrap configuration and load it.

I would like a review from you guys if the way I've done is ok or if I'm breaking any pattern that you could be using.

Thanks
Romulo
