### PR TITLE
Add src-path option to run command

### DIFF
--- a/src/PHPSpec2/Console/Command/RunCommand.php
+++ b/src/PHPSpec2/Console/Command/RunCommand.php
@@ -36,6 +36,7 @@ class RunCommand extends Command
         $this->setDefinition(array(
             new InputArgument('spec', InputArgument::OPTIONAL, 'Specs to run', 'spec'),
             new InputOption('format', 'f', InputOption::VALUE_REQUIRED, 'Formatter', 'progress'),
+            new InputOption('src-path', null, InputOption::VALUE_REQUIRED, 'Source path', 'src'),
         ));
     }
 
@@ -57,7 +58,7 @@ class RunCommand extends Command
         $specifications = $this->createLocator()->getSpecifications($input->getArgument('spec'));
         $runner         = $this->createRunner($matchers, $mocker, $unwrapper);
 
-        $this->configureAdditionalListeners();
+        $this->configureAdditionalListeners($input->getOption('src-path'));
         $this->dispatcher->dispatch('beforeSuite', new Event\SuiteEvent($collector));
 
         $result = 0;
@@ -143,9 +144,9 @@ class RunCommand extends Command
         return $formatter;
     }
 
-    protected function configureAdditionalListeners()
+    protected function configureAdditionalListeners($srcPath)
     {
-        $this->dispatcher->addSubscriber(new Listener\ClassNotFoundListener($this->io));
+        $this->dispatcher->addSubscriber(new Listener\ClassNotFoundListener($this->io, $srcPath));
         $this->dispatcher->addSubscriber(new Listener\MethodNotFoundListener($this->io));
     }
 }

--- a/src/PHPSpec2/Listener/ClassNotFoundListener.php
+++ b/src/PHPSpec2/Listener/ClassNotFoundListener.php
@@ -15,10 +15,16 @@ class ClassNotFoundListener implements EventSubscriberInterface
     private $path;
     private $proposedClasses = array();
 
-    public function __construct(IO $io, $path = 'src')
+    public function __construct(IO $io, $path)
     {
         $this->io   = $io;
-        $this->path = rtrim($path, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+
+        if ($path == '') {
+            $this->path =  $path;
+        } else {
+            $this->path = rtrim($path, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+        }
+
     }
 
     public static function getSubscribedEvents()


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
tests pass: yes
Fixes the following issues: #67

This PR adds a src-path option to the run console command to give the ability to generate classes in a location other than "src". 
