### PR TITLE
Added MockExpectation return self method for chaining

### DIFF
--- a/src/PHPSpec2/Mocker/MockExpectation.php
+++ b/src/PHPSpec2/Mocker/MockExpectation.php
@@ -73,6 +73,13 @@ class MockExpectation implements ArrayAccess
         return $this;
     }
 
+    public function willReturnSelf()
+    {
+        $this->willReturn($this->mock);
+
+        return $this;
+    }
+
     public function willThrow($exception, $message = '')
     {
         if ($exception instanceof \Exception) {


### PR DESCRIPTION
It's a small thing and don't know if it's actually needed but I found this usefull in chaining methods of mocks.

For example:

This is how it is now:

``` php
$mockedObject->firstChainingMethod()->willReturn($mockedObject);
$mockedObject->finalChainingMethod()->willReturn(new \ArrayObject());
```

And this is how it could be nicer:

``` php
$mockedObject->firstChainingMethod()->willReturnSelf();
$mockedObject->finalChainingMethod()->willReturn(new \ArrayObject());
```
