### PR TITLE
Require current working directory autoload

### DIFF
--- a/bin/phpspec
+++ b/bin/phpspec
@@ -3,6 +3,10 @@
 
 define('PHPSPEC2_VERSION', '2.0.1-PREVIEW');
 
+if (is_dir($vendor = getcwd() . '/vendor')) {
+    require $vendor . '/autoload.php';
+}
+
 if (is_dir($vendor = __DIR__ . '/../vendor')) {
     require($vendor . '/autoload.php');
 } elseif (is_dir($vendor = __DIR__ . '/../../../../vendor')) {


### PR DESCRIPTION
I have a directory `$HOME/.php` where i have a `composer.json` file with
libraries and/or utilities i want installed system wide. This is then in
my path. In my projects i have access to `phpspec` command line. But
because the bin script only autoloads itself it will never be able to
autoload my project.

This includes the local project autoloader.
