### PR TITLE
Return exit code from doRun method

### DIFF
--- a/src/PHPSpec2/Console/Application.php
+++ b/src/PHPSpec2/Console/Application.php
@@ -228,6 +228,6 @@ class Application extends BaseApplication
             $input = new ArrayInput(array('command' => 'run'));
         }
 
-        parent::doRun($input, $output);
+        return parent::doRun($input, $output);
     }
 }


### PR DESCRIPTION
Exit code was not returned so travis for example did not report about failed specs. This PR fix the it.
