### PR TITLE
Fixed failing method calling on mock prophets

### DIFF
--- a/src/PHPSpec2/Prophet/MockProphet.php
+++ b/src/PHPSpec2/Prophet/MockProphet.php
@@ -47,9 +47,7 @@ class MockProphet implements ProphetInterface
             $this->beAMockOf('stdClass');
         }
 
-        return new MockExpectation(
-            $this->subject, $method, $this->mocker, $this->unwrapper, $this->presenter
-        );
+        return $this->createMethodMockExpectation($method);
     }
 
     public function __call($method, array $arguments)
@@ -58,11 +56,18 @@ class MockProphet implements ProphetInterface
             $this->beAMockOf('stdClass');
         }
 
-        return call_user_func_array($this->$method, $arguments);
+        return call_user_func_array($this->createMethodMockExpectation($method), $arguments);
     }
 
     public function getWrappedSubject()
     {
         return $this->subject;
+    }
+
+    protected function createMethodMockExpectation($method)
+    {
+        return new MockExpectation(
+            $this->subject, $method, $this->mocker, $this->unwrapper, $this->presenter
+        );
     }
 }


### PR DESCRIPTION
If I've got a class like this 

``` php
class Foo()
{
    protected $bar;

    public function bar() { ... }
}
```

I know this isn't a best practice to name methods exactly the same as properties but this is what f.e. Propel has in one of it's core query building class.

So if you make a mock of this class

``` php
$fooMock->beAMockOf('\Foo');
$fooMock->bar()->willReturn(true); 
```

and run your specs you will get an access violation error saying that you're trying to access a protected property bar (note that you were calling a method not accessing a property).

This happens due to how `MockProphet` handles method calling: 

``` php
//...
return call_user_func_array($this->$method, $arguments);
```
