### PR TITLE
[WIP] Static construction of objects

### DIFF
--- a/src/PHPSpec2/Console/Application.php
+++ b/src/PHPSpec2/Console/Application.php
@@ -178,6 +178,10 @@ class Application extends BaseApplication
         });
 
         $c->extend('event_dispatcher.listeners', function($c) {
+            return new Listener\FactoryMethodNotFoundListener($c('io'));
+        });
+
+        $c->extend('event_dispatcher.listeners', function($c) {
             return new Listener\MethodNotFoundListener($c('io'));
         });
 

--- a/src/PHPSpec2/Exception/FactoryMethodNotFoundException.php
+++ b/src/PHPSpec2/Exception/FactoryMethodNotFoundException.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace PHPSpec2\Exception;
+
+class FactoryMethodNotFoundException extends Exception
+{
+    private $subject;
+    private $method;
+    private $arguments;
+
+    public function __construct($message, $subject, $method, array $arguments = array())
+    {
+        parent::__construct($message);
+
+        $this->subject = $subject;
+        $this->method = $method;
+        $this->arguments = $arguments;
+    }
+
+    public function getSubject()
+    {
+        return $this->subject;
+    }
+
+    public function getMethod()
+    {
+        return $this->method;
+    }
+
+    public function getArguments()
+    {
+        return $this->arguments;
+    }
+}

--- a/src/PHPSpec2/Listener/FactoryMethodNotFoundListener.php
+++ b/src/PHPSpec2/Listener/FactoryMethodNotFoundListener.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace PHPSpec2\Listener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use PHPSpec2\Event\ExampleEvent;
+use PHPSpec2\Console\IO;
+use PHPSpec2\Exception\FactoryMethodNotFoundException;
+
+class FactoryMethodNotFoundListener implements EventSubscriberInterface
+{
+    private $io;
+    private $proposedMethods = array();
+
+    public function __construct(IO $io)
+    {
+        $this->io = $io;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array('afterExample' => 'afterExample');
+    }
+
+    public function afterExample(ExampleEvent $event)
+    {
+        $exception = $event->getException();
+        if (null !== $exception && $exception instanceof FactoryMethodNotFoundException) {
+            if (null === $ioTemp = $this->io->cutTemp()) {
+                if ("\n" !== $this->io->getLastWrittenMessage()) {
+                    $this->io->writeln();
+                }
+            }
+            $shortcut = $exception->getSubject().'::'.$exception->getMethod();
+            if (in_array($shortcut, $this->proposedMethods)) {
+                return;
+            }
+            $this->proposedMethods[] = $shortcut;
+
+            if ($this->io->askConfirmation('Do you want me to create this factory method for you?')) {
+                $class  = new \ReflectionClass($exception->getSubject());
+                $method = $exception->getMethod();
+
+                $content = file_get_contents($class->getFileName());
+                $content = preg_replace(
+                    '/}[ \n]*$/', $this->getMethodContentFor($method) ."\n}\n", $content
+                );
+
+                file_put_contents($class->getFileName(), $content);
+
+                $this->io->writeln(sprintf(
+                        "\n<info>Factory Method <value>%s::%s()</value> has been created.</info>",
+                        $class->getName(), $method
+                    ), 6);
+            }
+
+            $this->io->writeln();
+            if (null !== $ioTemp) {
+                $this->io->writeTemp($ioTemp);
+            }
+        }
+    }
+
+    protected function getMethodContentFor($method)
+    {
+        $template = file_get_contents(__DIR__.'/../Resources/templates/factorymethod.php');
+
+        return rtrim(strtr($template, array('%method%' => $method)));
+    }
+}

--- a/src/PHPSpec2/Prophet/ObjectProphet.php
+++ b/src/PHPSpec2/Prophet/ObjectProphet.php
@@ -25,7 +25,11 @@ use ArrayAccess;
 
 class ObjectProphet implements ArrayAccess, ProphetInterface
 {
+    /**
+     * @var \PHPSpec2\Subject\LazySubjectInterface
+     */
     private $subject;
+
     private $matchers;
     private $unwrapper;
     private $presenter;
@@ -72,6 +76,11 @@ class ObjectProphet implements ArrayAccess, ProphetInterface
         }
 
         $this->subject->setConstructorArguments($this->unwrapper->unwrapAll(func_get_args()));
+    }
+
+    public function beCreatedStaticallyWith(Callable $factoryCallable, array $arguments = array())
+    {
+        $this->subject->setFactoryMethod($factoryCallable, $arguments);
     }
 
     public function should($name = null, array $arguments = array())

--- a/src/PHPSpec2/Prophet/ObjectProphet.php
+++ b/src/PHPSpec2/Prophet/ObjectProphet.php
@@ -78,9 +78,15 @@ class ObjectProphet implements ArrayAccess, ProphetInterface
         $this->subject->setConstructorArguments($this->unwrapper->unwrapAll(func_get_args()));
     }
 
-    public function beCreatedStaticallyWith(Callable $factoryCallable, array $arguments = array())
+    /**
+     * Set a Factory to instantiate the object
+     *
+     * @param $factory string|Callable Either a static factory method on the class under spec, or a callable to a factory
+     *                 method, such as array('Class', 'method')
+     */
+    public function beConstructedThrough($factory)
     {
-        $this->subject->setFactoryMethod($factoryCallable, $arguments);
+        $this->subject->setFactory($factory);
     }
 
     public function should($name = null, array $arguments = array())

--- a/src/PHPSpec2/Resources/templates/factorymethod.php
+++ b/src/PHPSpec2/Resources/templates/factorymethod.php
@@ -1,0 +1,6 @@
+
+    public static function %method%()
+    {
+        // TODO: implement
+        return new static();
+    }

--- a/src/PHPSpec2/Subject/LazyObject.php
+++ b/src/PHPSpec2/Subject/LazyObject.php
@@ -64,10 +64,12 @@ class LazyObject implements LazySubjectInterface
 
         $reflection = new ReflectionClass($this->classname);
 
-        if (!empty($this->arguments)) {
-            return $this->instance = $reflection->newInstanceArgs($this->arguments);
+        if (empty($this->arguments)) {
+            $this->instance = $reflection->newInstance();
+        } else {
+            $this->instance = $reflection->newInstanceArgs($this->arguments);
         }
 
-        return $this->instance = $reflection->newInstance();
+        return $this->instance;
     }
 }

--- a/src/PHPSpec2/Subject/LazyObject.php
+++ b/src/PHPSpec2/Subject/LazyObject.php
@@ -14,7 +14,7 @@ class LazyObject implements LazySubjectInterface
     private $arguments;
     private $presenter;
     private $instance;
-    private $factoryMethod;
+    private $factory = '__construct';
 
     public function __construct($classname = null, array $arguments = array(),
                                 PresenterInterface $presenter)
@@ -63,22 +63,20 @@ class LazyObject implements LazySubjectInterface
             ), $this->classname);
         }
 
-        $reflection = new ReflectionClass($this->classname);
-
-        if ($this->factoryMethod) {
-            $this->instance = call_user_func_array($this->factoryMethod, $this->arguments);
-        } elseif (empty($this->arguments)) {
-            $this->instance = $reflection->newInstance();
-        } else {
+        if ($this->factory == '__construct') {
+            $reflection = new ReflectionClass($this->classname);
             $this->instance = $reflection->newInstanceArgs($this->arguments);
+        } elseif (is_string($this->factory)) {
+            $this->instance = call_user_func_array(array($this->classname, $this->factory), $this->arguments);
+        } elseif (is_callable($this->factory)) {
+            $this->instance = call_user_func_array($this->factory, $this->arguments);
         }
 
         return $this->instance;
     }
 
-    public function setFactoryMethod(Callable $factoryMethod, $arguments)
+    public function setFactory($factory)
     {
-        $this->factoryMethod = $factoryMethod;
-        $this->arguments = $arguments;
+        $this->factory = $factory;
     }
 }

--- a/src/PHPSpec2/Subject/LazyObject.php
+++ b/src/PHPSpec2/Subject/LazyObject.php
@@ -6,6 +6,7 @@ use ReflectionClass;
 
 use PHPSpec2\Exception\Exception;
 use PHPSpec2\Exception\ClassNotFoundException;
+use PHPSpec2\Exception\FactoryMethodNotFoundException;
 use PHPSpec2\Formatter\Presenter\PresenterInterface;
 
 class LazyObject implements LazySubjectInterface
@@ -67,6 +68,11 @@ class LazyObject implements LazySubjectInterface
             $reflection = new ReflectionClass($this->classname);
             $this->instance = $reflection->newInstanceArgs($this->arguments);
         } elseif (is_string($this->factory)) {
+            if (!method_exists($this->classname, $this->factory)) {
+                throw new FactoryMethodNotFoundException(sprintf(
+                    'Method %s::%s does not exists.', $this->presenter->presentString($this->classname), $this->presenter->presentString($this->factory)
+                ), $this->classname, $this->factory);
+            }
             $this->instance = call_user_func_array(array($this->classname, $this->factory), $this->arguments);
         } elseif (is_callable($this->factory)) {
             $this->instance = call_user_func_array($this->factory, $this->arguments);

--- a/src/PHPSpec2/Subject/LazyObject.php
+++ b/src/PHPSpec2/Subject/LazyObject.php
@@ -14,6 +14,7 @@ class LazyObject implements LazySubjectInterface
     private $arguments;
     private $presenter;
     private $instance;
+    private $factoryMethod;
 
     public function __construct($classname = null, array $arguments = array(),
                                 PresenterInterface $presenter)
@@ -64,12 +65,20 @@ class LazyObject implements LazySubjectInterface
 
         $reflection = new ReflectionClass($this->classname);
 
-        if (empty($this->arguments)) {
+        if ($this->factoryMethod) {
+            $this->instance = call_user_func_array($this->factoryMethod, $this->arguments);
+        } elseif (empty($this->arguments)) {
             $this->instance = $reflection->newInstance();
         } else {
             $this->instance = $reflection->newInstanceArgs($this->arguments);
         }
 
         return $this->instance;
+    }
+
+    public function setFactoryMethod(Callable $factoryMethod, $arguments)
+    {
+        $this->factoryMethod = $factoryMethod;
+        $this->arguments = $arguments;
     }
 }


### PR DESCRIPTION
As discussed in #79.

The code is just a POC and there are no specs yet. I figured I'd first try to get it working before diving in too deep.

This fixes my use case where I want to instantiate an object without using it's constructor directly.

Simplified example:

```
class Payment
{
    private $amount;
    private function __construct($amount)
    {
        $this->amount = $amount;
    }

    public static function create($amount)
    {
        return new static($amount);
    }
}
```

In production code, you'd instantiate the Payment like this:

```
$payment = Payment::create(500);
```

In phpspec:

```
$this->beCreatedStaticallyWith(array('Payment', 'create'), array($amount));
```
