### PR TITLE
Inheriting specifications

### DIFF
--- a/src/PHPSpec2/Runner/Runner.php
+++ b/src/PHPSpec2/Runner/Runner.php
@@ -136,7 +136,7 @@ class Runner
 
     public function runExample(Node\Example $example, Matcher\MatchersCollection $matchers)
     {
-        $context       = $example->getFunction()->getDeclaringClass()->newInstance();
+        $context       =  $this->getExampleContext($example);
         $collaborators = new Prophet\CollaboratorsCollection($this->presenter);
 
         foreach ($this->getExampleInitializers() as $initializer) {
@@ -230,5 +230,21 @@ class Runner
 
         // error reporting turned off or more likely suppressed with @
         return false;
+    }
+
+    /**
+     * Returns an instance of the class in which context we run the example
+     * @param \PHPSpec2\Loader\Node\Example $example
+     * @return mixed
+     */
+    private function getExampleContext(Node\Example $example)
+    {
+        if (null !== $example->getSpecification()){
+            $declaringClass =  $example->getSpecification()->getClass();
+        }
+        else {
+            $declaringClass = $example->getFunction()->getDeclaringClass();
+        }
+        return $declaringClass->newInstance();
     }
 }


### PR DESCRIPTION
In case we have classes that share similar behavior, it would be nice to specify it only in one place. For example, if we have inherited classes. Connected to issue #88 
I think the most natural way is to inherit the specification. To make it work we need a slight modification in the way the context of the example is determined.  If we use declaring class of the method, then  we incorrectly get parent class. So, first we try to get the class from specification. If it does not exist, we fallback to the class which declared the method.
