### PR TITLE
Fix issue when using during with only method name as parameter

### DIFF
--- a/src/PHPSpec2/Matcher/ThrowMatcher.php
+++ b/src/PHPSpec2/Matcher/ThrowMatcher.php
@@ -109,7 +109,7 @@ class ThrowMatcher implements MatcherInterface
                     $callable = lcfirst($matches[1]);
                 } elseif (isset($arguments[0])) {
                     $callable  = $arguments[0];
-                    $arguments = $arguments[1];
+                    $arguments = isset($arguments[1]) ? $arguments[1] : array();
                 } else {
                     throw new MatcherException('Provide callable to be checked for throwing.');
                 }


### PR DESCRIPTION
``` php
$this->shouldThrow('\RuntimeException')->during('getProjectRole');
```

This expectation failed with an error: 

``` php
notice: Undefined offset: 1 in ...phpspec/phpspec2/src/PHPSpec2/Matcher/ThrowMatcher.php line 112
```
