### PR TITLE
fixed getting cause from exceptions

### DIFF
--- a/spec/PHPSpec2/Formatter/Presenter/StringPresenter.php
+++ b/spec/PHPSpec2/Formatter/Presenter/StringPresenter.php
@@ -3,8 +3,11 @@
 namespace spec\PHPSpec2\Formatter\Presenter;
 
 use PHPSpec2\ObjectBehavior;
+use PHPSpec2\Exception\Exception as PHPSpec2Exception;
+use PHPSpec2\Matcher\CustomMatchersProviderInterface;
+use PHPSpec2\Matcher\InlineMatcher;
 
-class StringPresenter extends ObjectBehavior
+class StringPresenter extends ObjectBehavior implements CustomMatchersProviderInterface
 {
     /**
      * @param PHPSpec2\Formatter\Presenter\Differ\Differ $differ
@@ -65,5 +68,44 @@ class StringPresenter extends ObjectBehavior
     function it_should_present_string_as_string()
     {
         $this->presentString('some string')->shouldReturn('some string');
+    }
+
+    function it_should_present_exception_without_cause()
+    {
+        $exception = new PHPSpec2Exception('message');
+
+        $this->presentException($exception)
+            ->shouldReturn('message');
+    }
+
+    function it_should_present_exception_with_cause()
+    {
+        $reflection = new \ReflectionClass(__CLASS__);
+
+        $exception = new PHPSpec2Exception('message');
+        $exception->setCause($reflection);
+
+        $this->presentException($exception)
+            ->shouldReturn('message');
+    }
+
+    function it_should_present_exception_with_cause_if_verbose()
+    {
+        $reflection = new \ReflectionClass(__CLASS__);
+
+        $exception = new PHPSpec2Exception('message');
+        $exception->setCause($reflection);
+
+        $this->presentException($exception, true)
+            ->shouldStartWith("message\n\n");
+    }
+
+    public static function getMatchers()
+    {
+        return array(
+            new InlineMatcher('startWith', function ($subject, $beginning) {
+                return strpos($subject, $beginning) === 0;
+            })
+        );
     }
 }

--- a/src/PHPSpec2/Exception/Exception.php
+++ b/src/PHPSpec2/Exception/Exception.php
@@ -4,4 +4,15 @@ namespace PHPSpec2\Exception;
 
 class Exception extends \Exception
 {
+    protected $cause;
+
+    public function getCause()
+    {
+        return $this->cause;
+    }
+
+    public function setCause($cause)
+    {
+        $this->cause = $cause;
+    }
 }

--- a/src/PHPSpec2/Formatter/Presenter/StringPresenter.php
+++ b/src/PHPSpec2/Formatter/Presenter/StringPresenter.php
@@ -211,13 +211,13 @@ class StringPresenter implements PresenterInterface
 
     protected function getExceptionExamplePosition(Exception $exception)
     {
-        $refl = $exception->cause;
+        $refl = $exception->getCause();
         foreach ($exception->getTrace() as $call) {
             if (!isset($call['file'])) {
                 continue;
             }
 
-            if ($refl->getFilename() === $call['file']) {
+            if (!empty($refl) && $refl->getFilename() === $call['file']) {
                 return array($call['file'], $call['line']);
             }
         }

--- a/src/PHPSpec2/Formatter/PrettyFormatter.php
+++ b/src/PHPSpec2/Formatter/PrettyFormatter.php
@@ -126,8 +126,9 @@ class PrettyFormatter implements FormatterInterface
             return;
         }
 
-        // TODO: add cause to exception interface
-        $exception->cause = $event->getExample()->getFunction();
+        if ($exception instanceof PHPSpec2Exception) {
+            $exception->setCause($event->getExample()->getFunction());
+        }
         $depth = $depth ?: (($event->getExample()->getDepth() * 2) + 6);
         $message = $this->presenter->presentException($exception, $this->io->isVerbose());
 

--- a/src/PHPSpec2/Formatter/ProgressFormatter.php
+++ b/src/PHPSpec2/Formatter/ProgressFormatter.php
@@ -10,6 +10,7 @@ use PHPSpec2\Event\SuiteEvent;
 use PHPSpec2\Event\SpecificationEvent;
 use PHPSpec2\Event\ExampleEvent;
 use PHPSpec2\Exception\Example\PendingException;
+use PHPSpec2\Exception\Exception as PHPSpec2Exception;
 
 class ProgressFormatter implements FormatterInterface
 {
@@ -112,7 +113,9 @@ class ProgressFormatter implements FormatterInterface
 
         $title = str_replace('\\', DIRECTORY_SEPARATOR, $event->getSpecification()->getTitle());
         $title = str_pad($title, 50, ' ', STR_PAD_RIGHT);
-        $exception->cause = $event->getExample()->getFunction();
+        if ($exception instanceof PHPSpec2Exception) {
+            $exception->setCause($event->getExample()->getFunction());
+        }
         $message = $this->presenter->presentException($exception, $this->io->isVerbose());
 
         if ($exception instanceof PendingException) {


### PR DESCRIPTION
The formatters are accessing the `$cause` property of any exception as if it was defined and public. 
This can lead to fatal errors when an Exception class is caught that actually has a property named `$cause` and it is not public f.e.:

``` php
PHP Fatal error:  Cannot access protected property SomeException::$cause in "..."/vendor/phpspec/phpspec2/src/PHPSpec2/Formatter/ProgressFormatter.php on line 115
```
