### PR TITLE
Update src/PHPSpec2/Matcher/ThrowMatcher.php

### DIFF
--- a/src/PHPSpec2/Matcher/ThrowMatcher.php
+++ b/src/PHPSpec2/Matcher/ThrowMatcher.php
@@ -108,6 +108,9 @@ class ThrowMatcher implements MatcherInterface
                 if (preg_match('/^during(.+)$/', $method, $matches)) {
                     $callable = lcfirst($matches[1]);
                 } elseif (isset($arguments[0])) {
+                    if (strpos($method, 'during') === false) {
+                        throw new MatcherException('Incorrect usage of matcher Throw, either prefix the method with "during" and capitalize the first character of the method or use ->during(\'callable\', array(arguments)).' .PHP_EOL. 'E.g.'.PHP_EOL.'->during' . ucfirst($method) . '(arguments)'.PHP_EOL.'or'.PHP_EOL.'->during(\'' . $method . '\', array(arguments))');
+                    }
                     $callable  = $arguments[0];
                     $arguments = isset($arguments[1]) ? $arguments[1] : array();
                 } else {


### PR DESCRIPTION
Added an exception to make it clear to the user how to use this method, if used incorrectly. I saw you already corrected the $arguments[1] notice.
