### PR TITLE
Add a "shouldMatchPattern" matcher.

### DIFF
--- a/spec/PHPSpec2/Matcher/PatternMatcher.php
+++ b/spec/PHPSpec2/Matcher/PatternMatcher.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace spec\PHPSpec2\Matcher;
+
+use PHPSpec2\ObjectBehavior;
+use PHPSpec2\Exception\Example\FailureException;
+
+class PatternMatcher extends ObjectBehavior
+{
+    /**
+     * @param PHPSpec2\Formatter\Presenter\StringPresenter $presenter
+     */
+    public function let($presenter)
+    {
+        $presenter->presentString(ANY_ARGUMENTS)->willReturnArgument();
+        $presenter->presentString(ANY_ARGUMENTS)->willReturnArgument();
+
+        $this->beConstructedWith($presenter);
+    }
+
+    public function it_should_be_initializable()
+    {
+        $this->shouldHaveType('PHPSpec2\Matcher\PatternMatcher');
+    }
+
+    public function it_should_support_match()
+    {
+        $this->supports('matchPattern', 'subj', array('/^jbus$/'))->shouldReturn(true);
+    }
+
+    public function it_shouldnt_support_match_if_no_pattern_is_given()
+    {
+        $this->supports('matchPattern', 'subj', array())->shouldReturn(false);
+    }
+
+    public function it_throws_exception_when_subject_doesnt_match_pattern_but_should()
+    {
+        $this->shouldThrow(
+            new FailureException("subj doesn't match /^jbus$/, but it should.")
+        )->duringPositiveMatch('match', 'subj', array('/^jbus$/'));
+    }
+
+    public function it_should_match_when_subject_matches_pattern()
+    {
+        $this->shouldNotThrow()->duringPositiveMatch('match', 'subj', array('/^subj$/'));
+    }
+
+    public function it_throws_exception_when_subject_matches_pattern_but_shouldnt()
+    {
+        $this->shouldThrow(
+            new FailureException("subj matches /^subj$/, but it shouldn't.")
+        )->duringNegativeMatch('match', 'subj', array('/^subj$/'));
+    }
+
+    public function it_should_mismatch_when_subject_doesnt_match_pattern()
+    {
+        $this->shouldNotThrow()->duringNegativeMatch('match', 'subj', array('/^jbus$/'));
+    }
+}

--- a/src/PHPSpec2/Initializer/DefaultMatchersInitializer.php
+++ b/src/PHPSpec2/Initializer/DefaultMatchersInitializer.php
@@ -38,5 +38,6 @@ class DefaultMatchersInitializer implements SpecificationInitializerInterface
         $matchers->add(new Matcher\TypeMatcher($this->presenter));
         $matchers->add(new Matcher\ObjectStateMatcher($this->presenter));
         $matchers->add(new Matcher\ScalarMatcher($this->presenter));
+        $matchers->add(new Matcher\PatternMatcher($this->presenter));
     }
 }

--- a/src/PHPSpec2/Matcher/PatternMatcher.php
+++ b/src/PHPSpec2/Matcher/PatternMatcher.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace PHPSpec2\Matcher;
+
+use PHPSpec2\Formatter\Presenter\PresenterInterface;
+use PHPSpec2\Exception\Example\FailureException;
+
+class PatternMatcher extends BasicMatcher
+{
+    private $presenter;
+
+    public function __construct(PresenterInterface $presenter)
+    {
+        $this->presenter = $presenter;
+    }
+
+    public function supports($name, $subject, array $arguments)
+    {
+        return 'matchPattern' === $name
+            && 1 == count($arguments);
+    }
+
+    protected function matches($subject, array $arguments)
+    {
+        return (bool) preg_match($arguments[0], $subject);
+    }
+
+    protected function getFailureException($name, $subject, array $arguments)
+    {
+        return new FailureException(sprintf(
+            "%s doesn't match %s, but it should.",
+            $this->presenter->presentString($subject),
+            $this->presenter->presentString($arguments[0])
+        ));
+    }
+
+    protected function getNegativeFailureException($name, $subject, array $arguments)
+    {
+        return new FailureException(sprintf(
+            "%s matches %s, but it shouldn't.",
+            $this->presenter->presentString($subject),
+            $this->presenter->presentString($arguments[0])
+        ));
+    }
+}


### PR DESCRIPTION
# Motivation

I'm currently writing the specification for an object that constructs internal URIs based on a few, possibly, sluggified strings. Among other things, I'd like to be able to assert that the URIs that the object produces conform to a certain pattern. Hence, the `shouldMatch` matcher.
## Example step

``` php
public function it_should_produce_a_uri_that_conforms_to_the_internal_standard()
{
    $this->generate('value1', 'value2')->shouldMatchPattern('/company:entity:[a-z0-9]+$/');
}
```
# Additional notes

You'll see from the associated commits that I originally called this matcher `StringMatcher`. This is because I toyed with including `shouldStartWith`, `shouldEndWith`, and `shouldContain` (which, unfortunately, is a type ambiguous name) matchers. Since it's the responsibility of the matcher to test whether or not the value matches a pattern, I renamed it to `PatternMatcher`.

It can easily be renamed back to the more generic `StringMatcher` if and when those additional matchers are required.
