### PR TITLE
Match all properties of exception and not only the message

### DIFF
--- a/spec/PHPSpec2/Matcher/ThrowMatcher.php
+++ b/spec/PHPSpec2/Matcher/ThrowMatcher.php
@@ -9,8 +9,10 @@ class ThrowMatcher extends ObjectBehavior
     /**
      * @param PHPSpec2\Wrapper\ArgumentsUnwrapper             $unwrapper
      * @param PHPSpec2\Formatter\Presenter\PresenterInterface $presenter
+     * @param PHPSpec2\Factory\ReflectionFactory              $factory
+     * @param \ReflectionClass              $refClass
      */
-    function let($unwrapper, $presenter)
+    function let($unwrapper, $presenter, $factory, $refClass)
     {
         $unwrapper->unwrapAll(ANY_ARGUMENTS)->willReturnUsing(function($arguments) {
             if (!is_array($arguments[0])) {
@@ -20,10 +22,11 @@ class ThrowMatcher extends ObjectBehavior
             return $arguments;
         });
 
-        $presenter->presentValue(ANY_ARGUMENTS)->willReturn('val1');
-        $presenter->presentValue(ANY_ARGUMENTS)->willReturn('val2');
+        $presenter->presentValue(ANY_ARGUMENTS)->willReturnArgument();
 
-        $this->beConstructedWith($unwrapper, $presenter);
+        $factory->create(ANY_ARGUMENT)->willReturn($refClass);
+
+        $this->beConstructedWith($unwrapper, $presenter, $factory);
     }
 
     function it_supports_the_throw_alias_for_object_and_exception_name()
@@ -34,7 +37,7 @@ class ThrowMatcher extends ObjectBehavior
     /**
      * @param Prophet $subject mock of stdClass
      */
-    function it_can_specify_a_method_during_which_an_exception_should_be_throw($subject)
+    function it_can_specify_a_method_during_which_an_exception_should_be_thrown($subject)
     {
         $subject->someMethod()->willThrow('\Exception');
 
@@ -44,8 +47,8 @@ class ThrowMatcher extends ObjectBehavior
     /**
      * @param Prophet $subject mock of stdClass
      */
-    function it_can_specify_a_method_during_which_an_exception_should_not_be_throw($subject)
+    function it_can_specify_a_method_during_which_an_exception_should_not_be_thrown($subject)
     {
-        $this->negativeMatch('throw', $subject, array('\Exception'))->duringSomeMethod(array());
+        $this->negativeMatch('throw', $subject, array(new \Exception('message', 2)))->duringSomeMethod(array());
     }
 }

--- a/src/PHPSpec2/Factory/ReflectionFactory.php
+++ b/src/PHPSpec2/Factory/ReflectionFactory.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace PHPSpec2\Factory;
+
+class ReflectionFactory
+{
+    public function create($class)
+    {
+        return new \ReflectionClass($class);
+    }
+}
+


### PR DESCRIPTION
Properties line and file are ignored, because they are environnement
related.
- should{Not}Throw('\Exception') will only match instance of
- should{Not}Throw(new \Exception('failure')) will only match message
  property
- should{Not}Throw(new \MyException('failure', 123, true)) will match
  message, code, and all other set custom properties
