### PR TITLE
Ignore 3 more irrevelant exception properties during matching

### DIFF
--- a/src/PHPSpec2/Matcher/ThrowMatcher.php
+++ b/src/PHPSpec2/Matcher/ThrowMatcher.php
@@ -57,7 +57,7 @@ class ThrowMatcher implements MatcherInterface
             if (is_object($exception)) {
                 $exceptionRefl = $this->factory->create($exception);
                 foreach ($exceptionRefl->getProperties() as $property) {
-                    if (in_array($property->getName(), array('file', 'line'))) {
+                    if (in_array($property->getName(), array('file', 'line', 'string', 'trace', 'previous'))) {
                         continue;
                     }
                     $property->setAccessible(true);
@@ -96,7 +96,7 @@ class ThrowMatcher implements MatcherInterface
                 if (is_object($exception)) {
                     $exceptionRefl = $this->factory->create($exception);
                     foreach ($exceptionRefl->getProperties() as $property) {
-                        if (in_array($property->getName(), array('file', 'line'))) {
+                        if (in_array($property->getName(), array('file', 'line', 'string', 'trace', 'previous'))) {
                             continue;
                         }
                         $property->setAccessible(true);


### PR DESCRIPTION
They are not documented on http://www.php.net/manual/fr/class.exception.php but they do exist!
