### PR TITLE
Update deps constraints for Symfony 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
 
     "require": {
         "php":                      ">=5.3.3",
-        "symfony/console":          ">=2.1, <2.3-dev",
-        "symfony/event-dispatcher": ">=2.1, <2.3-dev",
-        "symfony/finder":           ">=2.1, <2.3-dev",
-        "symfony/yaml":             ">=2.1, <2.3-dev",
+        "symfony/console":          ">=2.1, <3.0",
+        "symfony/event-dispatcher": ">=2.1, <3.0",
+        "symfony/finder":           ">=2.1, <3.0",
+        "symfony/yaml":             ">=2.1, <3.0",
         "mockery/mockery":          "0.7.*",
         "phpspec/php-diff":         "*@dev"
     },


### PR DESCRIPTION
Updates composer.json for Symfony2.3.
It's fine to use <3.0 I guess, as from 2.3 new releases should keep backward compatibility.
